### PR TITLE
get the raft_term included in double quote when displaying in hex

### DIFF
--- a/etcdctl/ctlv3/command/printer_json.go
+++ b/etcdctl/ctlv3/command/printer_json.go
@@ -66,10 +66,10 @@ func printMemberListWithHexJSON(r clientv3.MemberListResponse) {
 	buffer.WriteString("\",\"member_id\":\"")
 	b = strconv.AppendUint(nil, r.Header.MemberId, 16)
 	buffer.Write(b)
-	buffer.WriteString("\",\"raft_term\":")
+	buffer.WriteString("\",\"raft_term\":\"")
 	b = strconv.AppendUint(nil, r.Header.RaftTerm, 16)
 	buffer.Write(b)
-	buffer.WriteByte('}')
+	buffer.WriteString("\"}")
 	for i := 0; i < len(r.Members); i++ {
 		if i == 0 {
 			buffer.WriteString(",\"members\":[{\"ID\":\"")


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
