### PR TITLE
Log more time durations when range operation takes too long

### DIFF
--- a/server/etcdserver/apply_v2.go
+++ b/server/etcdserver/apply_v2.go
@@ -122,11 +122,11 @@ func (s *EtcdServer) applyV2Request(r *RequestV2, shouldApplyV3 membership.Shoul
 		stringer:    r,
 		alternative: func() string { return fmt.Sprintf("id:%d,method:%s,path:%s", r.ID, r.Method, r.Path) },
 	}
-	defer func(start time.Time) {
+	defer func(tr *TimeRecorder) {
 		success := resp.Err == nil
-		applySec.WithLabelValues(v2Version, r.Method, strconv.FormatBool(success)).Observe(time.Since(start).Seconds())
-		warnOfExpensiveRequest(s.Logger(), s.Cfg.WarningApplyDuration, start, stringer, nil, nil)
-	}(time.Now())
+		applySec.WithLabelValues(v2Version, r.Method, strconv.FormatBool(success)).Observe(tr.TotalDuration().Seconds())
+		warnOfExpensiveRequest(s.Logger(), s.Cfg.WarningApplyDuration, tr, stringer, nil, nil)
+	}(NewTimeRecorder())
 
 	switch r.Method {
 	case "POST":

--- a/server/etcdserver/util_bench_test.go
+++ b/server/etcdserver/util_bench_test.go
@@ -45,6 +45,6 @@ func BenchmarkWarnOfExpensiveRequestNoLog(b *testing.B) {
 	}
 	err := errors.New("benchmarking warn of expensive request")
 	for n := 0; n < b.N; n++ {
-		warnOfExpensiveRequest(testLogger, time.Second, time.Now(), nil, m, err)
+		warnOfExpensiveRequest(testLogger, time.Second, NewTimeRecorder(), nil, m, err)
 	}
 }


### PR DESCRIPTION
When it takes etcd a long time ( bigger than the threshold) to process a read-only range or Txn request, then it prints a warning something like below (printed by `etcd 3.4.13`),

`2022-02-16 02:19:15.900188 W | etcdserver: read-only range request "key:\"/registry/configmaps/kube-system/px-bootstrap-portworxfwanoprod\" " with result "range_response_count:1 size:974" took too long (304.089708ms) to execute
`

It's the total duration, and we don't' know how much time is contributed by peer communication, and how much time is contributed by the store range operation  So this PR is try to break down the total duration and add more info. In above example, the total duration is 304ms. Assuming the duration for the `applyV3Base.Range` is 100ms, then the output will be something like below

`total: 304ms, store-range: 100ms`

So we can calculate the duration for the peer communication is about 204ms (304-100). It's useful, because users can tell the reason (either network or disk I/O) for the slow request processing.

