### PR TITLE
add an applyLock to protect the applying workflow

### DIFF
--- a/server/storage/backend/batch_tx.go
+++ b/server/storage/backend/batch_tx.go
@@ -214,6 +214,8 @@ func unsafeForEach(tx *bolt.Tx, bucket Bucket, visitor func(k, v []byte) error) 
 
 // Commit commits a previous tx and begins a new writable one.
 func (t *batchTx) Commit() {
+	t.backend.LockApply()
+	defer t.backend.UnlockApply()
 	t.Lock()
 	t.commit(false)
 	t.Unlock()
@@ -221,6 +223,8 @@ func (t *batchTx) Commit() {
 
 // CommitAndStop commits the previous tx and does not create a new one.
 func (t *batchTx) CommitAndStop() {
+	t.backend.LockApply()
+	defer t.backend.UnlockApply()
 	t.Lock()
 	t.commit(true)
 	t.Unlock()
@@ -291,12 +295,16 @@ func (t *batchTxBuffered) Unlock() {
 }
 
 func (t *batchTxBuffered) Commit() {
+	t.backend.LockApply()
+	defer t.backend.UnlockApply()
 	t.Lock()
 	t.commit(false)
 	t.Unlock()
 }
 
 func (t *batchTxBuffered) CommitAndStop() {
+	t.backend.LockApply()
+	defer t.backend.UnlockApply()
 	t.Lock()
 	t.commit(true)
 	t.Unlock()

--- a/server/storage/mvcc/kvstore_test.go
+++ b/server/storage/mvcc/kvstore_test.go
@@ -916,6 +916,8 @@ func (b *fakeBackend) Snapshot() backend.Snapshot                               
 func (b *fakeBackend) ForceCommit()                                               {}
 func (b *fakeBackend) Defrag() error                                              { return nil }
 func (b *fakeBackend) Close() error                                               { return nil }
+func (b *fakeBackend) LockApply()                                                 {}
+func (b *fakeBackend) UnlockApply()                                               {}
 
 type indexGetResp struct {
 	rev     revision


### PR DESCRIPTION
The SetConsistentIndex is outside the transaction lock, so we add an
applyLock to make sure the SetConsistentIndex and the following apply
workflow are not interrupted by the periodic commit operation.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
