### PR TITLE
persist the consistent_index in the txPostLockHook

### DIFF
--- a/server/etcdserver/bootstrap.go
+++ b/server/etcdserver/bootstrap.go
@@ -203,7 +203,7 @@ func bootstrapSnapshot(cfg config.ServerConfig) *snap.Snapshotter {
 func bootstrapBackend(cfg config.ServerConfig, haveWAL bool, st v2store.Store, ss *snap.Snapshotter) (backend *bootstrappedBackend, err error) {
 	beExist := fileutil.Exist(cfg.BackendPath())
 	ci := cindex.NewConsistentIndex(nil)
-	beHooks := serverstorage.NewBackendHooks(cfg.Logger, ci)
+	beHooks := serverstorage.NewBackendHooks(cfg.Logger)
 	be := serverstorage.OpenBackend(cfg, beHooks)
 	defer func() {
 		if err != nil && be != nil {

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -2325,11 +2325,12 @@ func (s *EtcdServer) Version() *serverversion.Manager {
 	return serverversion.NewManager(s.Logger(), NewServerVersionAdapter(s))
 }
 
-func (s *EtcdServer) getTxPostLockInsideApplyHook() func() {
-	return func() {
+func (s *EtcdServer) getTxPostLockInsideApplyHook() func(backend.BatchTx) {
+	return func(tx backend.BatchTx) {
 		applyingIdx, applyingTerm := s.consistIndex.ConsistentApplyingIndex()
 		if applyingIdx > s.consistIndex.UnsafeConsistentIndex() {
 			s.consistIndex.SetConsistentIndex(applyingIdx, applyingTerm)
+			s.consistIndex.UnsafeSave(tx)
 		}
 	}
 }

--- a/server/etcdserver/server_test.go
+++ b/server/etcdserver/server_test.go
@@ -614,7 +614,7 @@ func TestApplyConfChangeShouldStop(t *testing.T) {
 		id:      1,
 		r:       *r,
 		cluster: cl,
-		beHooks: serverstorage.NewBackendHooks(lg, nil),
+		beHooks: serverstorage.NewBackendHooks(lg),
 	}
 	cc := raftpb.ConfChange{
 		Type:   raftpb.ConfChangeRemoveNode,
@@ -662,7 +662,7 @@ func TestApplyConfigChangeUpdatesConsistIndex(t *testing.T) {
 		cluster:      cl,
 		w:            wait.New(),
 		consistIndex: ci,
-		beHooks:      serverstorage.NewBackendHooks(lg, ci),
+		beHooks:      serverstorage.NewBackendHooks(lg),
 	}
 
 	// create EntryConfChange entry
@@ -743,7 +743,7 @@ func TestApplyMultiConfChangeShouldStop(t *testing.T) {
 		cluster:      cl,
 		w:            wait.New(),
 		consistIndex: ci,
-		beHooks:      serverstorage.NewBackendHooks(lg, ci),
+		beHooks:      serverstorage.NewBackendHooks(lg),
 	}
 	ents := []raftpb.Entry{}
 	for i := 1; i <= 4; i++ {
@@ -1113,7 +1113,7 @@ func TestSnapshotOrdering(t *testing.T) {
 		cluster:      cl,
 		SyncTicker:   &time.Ticker{},
 		consistIndex: ci,
-		beHooks:      serverstorage.NewBackendHooks(lg, ci),
+		beHooks:      serverstorage.NewBackendHooks(lg),
 	}
 	s.applyV2 = &applierV2store{store: s.v2store, cluster: s.cluster}
 
@@ -1262,7 +1262,7 @@ func TestConcurrentApplyAndSnapshotV3(t *testing.T) {
 		cluster:      cl,
 		SyncTicker:   &time.Ticker{},
 		consistIndex: ci,
-		beHooks:      serverstorage.NewBackendHooks(lg, ci),
+		beHooks:      serverstorage.NewBackendHooks(lg),
 	}
 	s.applyV2 = &applierV2store{store: s.v2store, cluster: s.cluster}
 
@@ -1347,7 +1347,7 @@ func TestAddMember(t *testing.T) {
 		reqIDGen:     idutil.NewGenerator(0, time.Time{}),
 		SyncTicker:   &time.Ticker{},
 		consistIndex: cindex.NewFakeConsistentIndex(0),
-		beHooks:      serverstorage.NewBackendHooks(lg, nil),
+		beHooks:      serverstorage.NewBackendHooks(lg),
 	}
 	s.start()
 	m := membership.Member{ID: 1234, RaftAttributes: membership.RaftAttributes{PeerURLs: []string{"foo"}}}
@@ -1394,7 +1394,7 @@ func TestRemoveMember(t *testing.T) {
 		reqIDGen:     idutil.NewGenerator(0, time.Time{}),
 		SyncTicker:   &time.Ticker{},
 		consistIndex: cindex.NewFakeConsistentIndex(0),
-		beHooks:      serverstorage.NewBackendHooks(lg, nil),
+		beHooks:      serverstorage.NewBackendHooks(lg),
 	}
 	s.start()
 	_, err := s.RemoveMember(context.Background(), 1234)
@@ -1440,7 +1440,7 @@ func TestUpdateMember(t *testing.T) {
 		reqIDGen:     idutil.NewGenerator(0, time.Time{}),
 		SyncTicker:   &time.Ticker{},
 		consistIndex: cindex.NewFakeConsistentIndex(0),
-		beHooks:      serverstorage.NewBackendHooks(lg, nil),
+		beHooks:      serverstorage.NewBackendHooks(lg),
 	}
 	s.start()
 	wm := membership.Member{ID: 1234, RaftAttributes: membership.RaftAttributes{PeerURLs: []string{"http://127.0.0.1:1"}}}

--- a/server/storage/backend/backend.go
+++ b/server/storage/backend/backend.go
@@ -69,7 +69,7 @@ type Backend interface {
 	Close() error
 
 	// SetTxPostLockInsideApplyHook sets a txPostLockInsideApplyHook.
-	SetTxPostLockInsideApplyHook(func())
+	SetTxPostLockInsideApplyHook(func(tx BatchTx))
 }
 
 type Snapshot interface {
@@ -123,7 +123,7 @@ type backend struct {
 	hooks Hooks
 
 	// txPostLockInsideApplyHook is called each time right after locking the tx.
-	txPostLockInsideApplyHook func()
+	txPostLockInsideApplyHook func(tx BatchTx)
 
 	lg *zap.Logger
 }
@@ -233,7 +233,7 @@ func (b *backend) BatchTx() BatchTx {
 	return b.batchTx
 }
 
-func (b *backend) SetTxPostLockInsideApplyHook(hook func()) {
+func (b *backend) SetTxPostLockInsideApplyHook(hook func(BatchTx)) {
 	// It needs to lock the batchTx, because the periodic commit
 	// may be accessing the txPostLockInsideApplyHook at the moment.
 	b.batchTx.lock()

--- a/server/storage/backend/batch_tx.go
+++ b/server/storage/backend/batch_tx.go
@@ -84,7 +84,7 @@ func (t *batchTx) LockInsideApply() {
 		// So we should check the txPostLockInsideApplyHook before validating
 		// the callstack.
 		ValidateCalledInsideApply(t.backend.lg)
-		t.backend.txPostLockInsideApplyHook()
+		t.backend.txPostLockInsideApplyHook(t)
 	}
 }
 

--- a/server/storage/backend/verify_test.go
+++ b/server/storage/backend/verify_test.go
@@ -28,7 +28,7 @@ func TestLockVerify(t *testing.T) {
 		name                      string
 		insideApply               bool
 		lock                      func(tx backend.BatchTx)
-		txPostLockInsideApplyHook func()
+		txPostLockInsideApplyHook func(backend.BatchTx)
 		expectPanic               bool
 	}{
 		{
@@ -47,7 +47,7 @@ func TestLockVerify(t *testing.T) {
 			name:                      "call lockInsideApply from outside apply (with txPostLockInsideApplyHook)",
 			insideApply:               false,
 			lock:                      lockInsideApply,
-			txPostLockInsideApplyHook: func() {},
+			txPostLockInsideApplyHook: func(backend.BatchTx) {},
 			expectPanic:               true,
 		},
 		{

--- a/server/storage/hooks.go
+++ b/server/storage/hooks.go
@@ -20,14 +20,12 @@ import (
 	"go.uber.org/zap"
 
 	"go.etcd.io/etcd/raft/v3/raftpb"
-	"go.etcd.io/etcd/server/v3/etcdserver/cindex"
 	"go.etcd.io/etcd/server/v3/storage/backend"
 	"go.etcd.io/etcd/server/v3/storage/schema"
 )
 
 type BackendHooks struct {
-	indexer cindex.ConsistentIndexer
-	lg      *zap.Logger
+	lg *zap.Logger
 
 	// confState to Be written in the next submitted Backend transaction (if dirty)
 	confState raftpb.ConfState
@@ -37,12 +35,11 @@ type BackendHooks struct {
 	confStateLock  sync.Mutex
 }
 
-func NewBackendHooks(lg *zap.Logger, indexer cindex.ConsistentIndexer) *BackendHooks {
-	return &BackendHooks{lg: lg, indexer: indexer}
+func NewBackendHooks(lg *zap.Logger) *BackendHooks {
+	return &BackendHooks{lg: lg}
 }
 
 func (bh *BackendHooks) OnPreCommitUnsafe(tx backend.BatchTx) {
-	bh.indexer.UnsafeSave(tx)
 	bh.confStateLock.Lock()
 	defer bh.confStateLock.Unlock()
 	if bh.confStateDirty {

--- a/server/storage/mvcc/kvstore_test.go
+++ b/server/storage/mvcc/kvstore_test.go
@@ -924,7 +924,7 @@ func (b *fakeBackend) Snapshot() backend.Snapshot                               
 func (b *fakeBackend) ForceCommit()                                               {}
 func (b *fakeBackend) Defrag() error                                              { return nil }
 func (b *fakeBackend) Close() error                                               { return nil }
-func (b *fakeBackend) SetTxPostLockInsideApplyHook(func())                        {}
+func (b *fakeBackend) SetTxPostLockInsideApplyHook(func(tx backend.BatchTx))      {}
 
 type indexGetResp struct {
 	rev     revision


### PR DESCRIPTION
Previously the consistent_index is persisted in the preCommitHook,
actually it isn't necessary. There isn't much performance gain, and
it complicate the complexity of the workflow.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
