### PR TITLE
verify consistent_index in snapshot must be equal to the snapshot index

### DIFF
--- a/client/pkg/verify/verify.go
+++ b/client/pkg/verify/verify.go
@@ -37,18 +37,30 @@ func IsVerificationEnabled(verification VerificationType) bool {
 	return env == string(ENV_VERIFY_VALUE_ALL) || env == strings.ToLower(string(verification))
 }
 
-// EnableVerifications returns a function that can be used to bring the original settings.
+// EnableVerifications sets `ENV_VERIFY` and returns a function that
+// can be used to bring the original settings.
 func EnableVerifications(verification VerificationType) func() {
 	previousEnv := getEnvVerify()
 	os.Setenv(ENV_VERIFY, string(verification))
 	return func() {
-		os.Setenv(ENV_VERIFY, string(previousEnv))
+		os.Setenv(ENV_VERIFY, previousEnv)
 	}
 }
 
-// EnableAllVerifications returns a function that can be used to bring the original settings.
+// EnableAllVerifications enables verification and returns a function
+// that can be used to bring the original settings.
 func EnableAllVerifications() func() {
 	return EnableVerifications(ENV_VERIFY_VALUE_ALL)
+}
+
+// DisableVerifications unsets `ENV_VERIFY` and returns a function that
+// can be used to bring the original settings.
+func DisableVerifications() func() {
+	previousEnv := getEnvVerify()
+	os.Unsetenv(ENV_VERIFY)
+	return func() {
+		os.Setenv(ENV_VERIFY, previousEnv)
+	}
 }
 
 // Verify performs verification if the assertions are enabled.

--- a/server/etcdserver/server_test.go
+++ b/server/etcdserver/server_test.go
@@ -34,6 +34,7 @@ import (
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
 	"go.etcd.io/etcd/client/pkg/v3/testutil"
 	"go.etcd.io/etcd/client/pkg/v3/types"
+	"go.etcd.io/etcd/client/pkg/v3/verify"
 	"go.etcd.io/etcd/pkg/v3/idutil"
 	"go.etcd.io/etcd/pkg/v3/pbutil"
 	"go.etcd.io/etcd/pkg/v3/wait"
@@ -1077,6 +1078,11 @@ func TestSnapshot(t *testing.T) {
 // TestSnapshotOrdering ensures raft persists snapshot onto disk before
 // snapshot db is applied.
 func TestSnapshotOrdering(t *testing.T) {
+	// Ignore the snapshot index verification in unit test, because
+	// it doesn't follow the e2e applying logic.
+	revertFunc := verify.DisableVerifications()
+	defer revertFunc()
+
 	lg := zaptest.NewLogger(t)
 	n := newNopReadyNode()
 	st := v2store.New()
@@ -1229,6 +1235,11 @@ func TestTriggerSnap(t *testing.T) {
 // TestConcurrentApplyAndSnapshotV3 will send out snapshots concurrently with
 // proposals.
 func TestConcurrentApplyAndSnapshotV3(t *testing.T) {
+	// Ignore the snapshot index verification in unit test, because
+	// it doesn't follow the e2e applying logic.
+	revertFunc := verify.DisableVerifications()
+	defer revertFunc()
+
 	lg := zaptest.NewLogger(t)
 	n := newNopReadyNode()
 	st := v2store.New()

--- a/server/etcdserver/snapshot_merge.go
+++ b/server/etcdserver/snapshot_merge.go
@@ -55,6 +55,8 @@ func (s *EtcdServer) createMergedSnapshotMessage(m raftpb.Message, snapt, snapi 
 	}
 	m.Snapshot = snapshot
 
+	verifySnapshotIndex(snapshot, s.consistIndex.ConsistentIndex())
+
 	return *snap.NewMessage(m, rc, dbsnap.Size())
 }
 


### PR DESCRIPTION
Usually the consistent_index should be greater than the latest snapshot
with suffix .snap. But for the snapshot coming from the leader, the
consistent_index should be equal to the snapshot index.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
