### PR TITLE
remove v2 client handler

### DIFF
--- a/server/etcdserver/api/v2http/client.go
+++ b/server/etcdserver/api/v2http/client.go
@@ -16,24 +16,9 @@
 package v2http
 
 import (
-	"net/http"
-	"time"
-
-	"go.etcd.io/etcd/server/v3/etcdserver"
-	"go.etcd.io/etcd/server/v3/etcdserver/api/etcdhttp"
 	"go.uber.org/zap"
+	"net/http"
 )
-
-// NewClientHandler generates a muxed http.Handler with the given parameters to serve etcd client requests.
-func NewClientHandler(lg *zap.Logger, server etcdserver.ServerPeer, timeout time.Duration) http.Handler {
-	if lg == nil {
-		lg = zap.NewNop()
-	}
-	mux := http.NewServeMux()
-	etcdhttp.HandleBasic(lg, mux, server)
-	etcdhttp.HandleMetricsHealth(lg, mux, server)
-	return requestLogger(lg, mux)
-}
 
 func requestLogger(lg *zap.Logger, handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/tests/framework/integration/cluster.go
+++ b/tests/framework/integration/cluster.go
@@ -35,7 +35,6 @@ import (
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/client/pkg/v3/testutil"
-	"go.etcd.io/etcd/client/pkg/v3/tlsutil"
 	"go.etcd.io/etcd/client/pkg/v3/transport"
 	"go.etcd.io/etcd/client/pkg/v3/types"
 	"go.etcd.io/etcd/client/v3"
@@ -47,7 +46,6 @@ import (
 	"go.etcd.io/etcd/server/v3/etcdserver/api/etcdhttp"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/membership"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/rafthttp"
-	"go.etcd.io/etcd/server/v3/etcdserver/api/v2http"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/v3client"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/v3election"
 	epb "go.etcd.io/etcd/server/v3/etcdserver/api/v3election/v3electionpb"
@@ -991,69 +989,7 @@ func (m *Member) Launch() error {
 		}
 		m.ServerClosers = append(m.ServerClosers, closer)
 	}
-	for _, ln := range m.ClientListeners {
-		hs := &httptest.Server{
-			Listener: ln,
-			Config: &http.Server{
-				Handler: v2http.NewClientHandler(
-					m.Logger,
-					m.Server,
-					m.ServerConfig.ReqTimeout(),
-				),
-				ErrorLog: log.New(io.Discard, "net/http", 0),
-			},
-		}
-		if m.ClientTLSInfo == nil {
-			hs.Start()
-		} else {
-			info := m.ClientTLSInfo
-			hs.TLS, err = info.ServerConfig()
-			if err != nil {
-				return err
-			}
 
-			// baseConfig is called on initial TLS handshake start.
-			//
-			// Previously,
-			// 1. Server has non-empty (*tls.Config).Certificates on client hello
-			// 2. Server calls (*tls.Config).GetCertificate iff:
-			//    - Server'Server (*tls.Config).Certificates is not empty, or
-			//    - Client supplies SNI; non-empty (*tls.ClientHelloInfo).ServerName
-			//
-			// When (*tls.Config).Certificates is always populated on initial handshake,
-			// client is expected to provide a valid matching SNI to pass the TLS
-			// verification, thus trigger server (*tls.Config).GetCertificate to reload
-			// TLS assets. However, a cert whose SAN field does not include domain names
-			// but only IP addresses, has empty (*tls.ClientHelloInfo).ServerName, thus
-			// it was never able to trigger TLS reload on initial handshake; first
-			// ceritifcate object was being used, never being updated.
-			//
-			// Now, (*tls.Config).Certificates is created empty on initial TLS client
-			// handshake, in order to trigger (*tls.Config).GetCertificate and populate
-			// rest of the certificates on every new TLS connection, even when client
-			// SNI is empty (e.g. cert only includes IPs).
-			//
-			// This introduces another problem with "httptest.Server":
-			// when server initial certificates are empty, certificates
-			// are overwritten by Go'Server internal test certs, which have
-			// different SAN fields (e.g. example.com). To work around,
-			// re-overwrite (*tls.Config).Certificates before starting
-			// test server.
-			tlsCert, err := tlsutil.NewCert(info.CertFile, info.KeyFile, nil)
-			if err != nil {
-				return err
-			}
-			hs.TLS.Certificates = []tls.Certificate{*tlsCert}
-
-			hs.StartTLS()
-		}
-		closer := func() {
-			ln.Close()
-			hs.CloseClientConnections()
-			hs.Close()
-		}
-		m.ServerClosers = append(m.ServerClosers, closer)
-	}
 	if m.GrpcURL != "" && m.Client == nil {
 		m.Client, err = NewClientV3(m)
 		if err != nil {


### PR DESCRIPTION
The V2ClientHandler is only used in integration test, but isn't used
in the production code anymore. So there is no reason to keep it.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
