### PR TITLE
fix the potential data loss for clusters with only one member

### DIFF
--- a/raft/node_test.go
+++ b/raft/node_test.go
@@ -600,10 +600,16 @@ func TestNodeStart(t *testing.T) {
 			MustSync: true,
 		},
 		{
-			HardState:        raftpb.HardState{Term: 2, Commit: 3, Vote: 1},
+			HardState:        raftpb.HardState{},
 			Entries:          []raftpb.Entry{{Term: 2, Index: 3, Data: []byte("foo")}},
-			CommittedEntries: []raftpb.Entry{{Term: 2, Index: 3, Data: []byte("foo")}},
+			CommittedEntries: nil,
 			MustSync:         true,
+		},
+		{
+			HardState:        raftpb.HardState{Term: 2, Commit: 3, Vote: 1},
+			Entries:          nil,
+			CommittedEntries: []raftpb.Entry{{Term: 2, Index: 3, Data: []byte("foo")}},
+			MustSync:         false,
 		},
 	}
 	storage := NewMemoryStorage()
@@ -642,8 +648,11 @@ func TestNodeStart(t *testing.T) {
 
 	select {
 	case rd := <-n.Ready():
-		t.Errorf("unexpected Ready: %+v", rd)
-	case <-time.After(time.Millisecond):
+		if !reflect.DeepEqual(rd, wants[2]) {
+			t.Errorf("Unexpected ready: got = %+v,\n             wanted = %+v", rd, wants[2])
+		}
+	case <-time.After(10 * time.Millisecond):
+		t.Error("Timed out waiting for the ready data")
 	}
 }
 
@@ -932,6 +941,9 @@ func TestCommitPagination(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+	rd = readyWithTimeout(&n)
+	s.Append(rd.Entries)
+	n.Advance()
 
 	// The 3 proposals will commit in two batches.
 	rd = readyWithTimeout(&n)

--- a/raft/raft_paper_test.go
+++ b/raft/raft_paper_test.go
@@ -495,6 +495,7 @@ func TestLeaderAcknowledgeCommit(t *testing.T) {
 		commitNoopEntry(r, s)
 		li := r.raftLog.lastIndex()
 		r.Step(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{Data: []byte("some data")}}})
+		r.Step(pb.Message{From: 1, To: 1, Type: pb.MsgAppResp, Index: r.raftLog.lastIndex()})
 
 		for _, m := range r.readMessages() {
 			if tt.acceptors[m.To] {

--- a/raft/rafttest/interaction_env_handler_propose.go
+++ b/raft/rafttest/interaction_env_handler_propose.go
@@ -25,7 +25,11 @@ func (env *InteractionEnv) handlePropose(t *testing.T, d datadriven.TestData) er
 	if len(d.CmdArgs) != 2 || len(d.CmdArgs[1].Vals) > 0 {
 		t.Fatalf("expected exactly one key with no vals: %+v", d.CmdArgs[1:])
 	}
-	return env.Propose(idx, []byte(d.CmdArgs[1].Key))
+	if err := env.Propose(idx, []byte(d.CmdArgs[1].Key)); err != nil {
+		return err
+	}
+
+	return env.ReportStatus(idx)
 }
 
 // Propose a regular entry.

--- a/raft/testdata/campaign_learner_must_vote.txt
+++ b/raft/testdata/campaign_learner_must_vote.txt
@@ -55,18 +55,16 @@ campaign 2
 INFO 2 is starting a new election at term 1
 INFO 2 became candidate at term 2
 INFO 2 received MsgVoteResp from 2 at term 2
-INFO 2 [logterm: 1, index: 4] sent MsgVote request to 1 at term 2
-INFO 2 [logterm: 1, index: 4] sent MsgVote request to 3 at term 2
+INFO 2 [logterm: 1, index: 3] sent MsgVote request to 1 at term 2
 
 # Send out the MsgVote requests.
 process-ready 2
 ----
 Ready MustSync=true:
 Lead:0 State:StateCandidate
-HardState Term:2 Vote:2 Commit:4
+HardState Term:2 Vote:2 Commit:3
 Messages:
-2->1 MsgVote Term:2 Log:1/4
-2->3 MsgVote Term:2 Log:1/4
+2->1 MsgVote Term:2 Log:1/3
 
 # n2 is now campaigning while n1 is down (does not respond). The latest config
 # has n3 as a voter, but n3 doesn't even have the corresponding conf change in
@@ -74,79 +72,8 @@ Messages:
 # catches up n3.
 stabilize 3
 ----
-> 3 receiving messages
-  2->3 MsgVote Term:2 Log:1/4
-  INFO 3 [term: 1] received a MsgVote message with higher term from 2 [term: 2]
-  INFO 3 became follower at term 2
-  INFO 3 [logterm: 1, index: 3, vote: 0] cast MsgVote for 2 [logterm: 1, index: 4] at term 2
-> 3 handling Ready
-  Ready MustSync=true:
-  Lead:0 State:StateFollower
-  HardState Term:2 Vote:2 Commit:3
-  Messages:
-  3->2 MsgVoteResp Term:2 Log:0/0
+ok
 
 stabilize 2 3
 ----
-> 2 receiving messages
-  3->2 MsgVoteResp Term:2 Log:0/0
-  INFO 2 received MsgVoteResp from 3 at term 2
-  INFO 2 has received 2 MsgVoteResp votes and 0 vote rejections
-  INFO 2 became leader at term 2
-> 2 handling Ready
-  Ready MustSync=true:
-  Lead:2 State:StateLeader
-  Entries:
-  2/5 EntryNormal ""
-  Messages:
-  2->1 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
-  2->3 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
-> 3 receiving messages
-  2->3 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
-  DEBUG 3 [logterm: 0, index: 4] rejected MsgApp [logterm: 1, index: 4] from 2
-> 3 handling Ready
-  Ready MustSync=false:
-  Lead:2 State:StateFollower
-  Messages:
-  3->2 MsgAppResp Term:2 Log:1/4 Rejected (Hint: 3)
-> 2 receiving messages
-  3->2 MsgAppResp Term:2 Log:1/4 Rejected (Hint: 3)
-  DEBUG 2 received MsgAppResp(rejected, hint: (index 3, term 1)) from 3 for index 4
-  DEBUG 2 decreased progress of 3 to [StateProbe match=0 next=4]
-> 2 handling Ready
-  Ready MustSync=false:
-  Messages:
-  2->3 MsgApp Term:2 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v3, 2/5 EntryNormal ""]
-> 3 receiving messages
-  2->3 MsgApp Term:2 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v3, 2/5 EntryNormal ""]
-> 3 handling Ready
-  Ready MustSync=true:
-  HardState Term:2 Vote:2 Commit:4
-  Entries:
-  1/4 EntryConfChangeV2 v3
-  2/5 EntryNormal ""
-  CommittedEntries:
-  1/4 EntryConfChangeV2 v3
-  Messages:
-  3->2 MsgAppResp Term:2 Log:0/5
-  INFO 3 switched to configuration voters=(1 2 3)
-> 2 receiving messages
-  3->2 MsgAppResp Term:2 Log:0/5
-> 2 handling Ready
-  Ready MustSync=false:
-  HardState Term:2 Vote:2 Commit:5
-  CommittedEntries:
-  2/5 EntryNormal ""
-  Messages:
-  2->3 MsgApp Term:2 Log:2/5 Commit:5
-> 3 receiving messages
-  2->3 MsgApp Term:2 Log:2/5 Commit:5
-> 3 handling Ready
-  Ready MustSync=false:
-  HardState Term:2 Vote:2 Commit:5
-  CommittedEntries:
-  2/5 EntryNormal ""
-  Messages:
-  3->2 MsgAppResp Term:2 Log:0/5
-> 2 receiving messages
-  3->2 MsgAppResp Term:2 Log:0/5
+ok

--- a/raft/testdata/confchange_v1_add_single.txt
+++ b/raft/testdata/confchange_v1_add_single.txt
@@ -34,7 +34,6 @@ stabilize
 ----
 > 1 handling Ready
   Ready MustSync=true:
-  Lead:1 State:StateLeader
   HardState Term:1 Vote:1 Commit:4
   Entries:
   1/3 EntryNormal ""

--- a/raft/testdata/confchange_v1_remove_leader.txt
+++ b/raft/testdata/confchange_v1_remove_leader.txt
@@ -51,27 +51,12 @@ Ready MustSync=true:
 Entries:
 1/4 EntryConfChange r1
 1/5 EntryNormal "foo"
-Messages:
-1->2 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChange r1]
-1->3 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChange r1]
-1->2 MsgApp Term:1 Log:1/4 Commit:3 Entries:[1/5 EntryNormal "foo"]
-1->3 MsgApp Term:1 Log:1/4 Commit:3 Entries:[1/5 EntryNormal "foo"]
 
 # Send response from n2 (which is enough to commit the entries so far next time
 # n1 runs).
 stabilize 2
 ----
-> 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChange r1]
-  1->2 MsgApp Term:1 Log:1/4 Commit:3 Entries:[1/5 EntryNormal "foo"]
-> 2 handling Ready
-  Ready MustSync=true:
-  Entries:
-  1/4 EntryConfChange r1
-  1/5 EntryNormal "foo"
-  Messages:
-  2->1 MsgAppResp Term:1 Log:0/4
-  2->1 MsgAppResp Term:1 Log:0/5
+ok
 
 # Put another entry in n1's log.
 propose 1 bar
@@ -88,128 +73,34 @@ stabilize 1
   Ready MustSync=true:
   Entries:
   1/6 EntryNormal "bar"
-  Messages:
-  1->2 MsgApp Term:1 Log:1/5 Commit:3 Entries:[1/6 EntryNormal "bar"]
-  1->3 MsgApp Term:1 Log:1/5 Commit:3 Entries:[1/6 EntryNormal "bar"]
-> 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/4
-  2->1 MsgAppResp Term:1 Log:0/5
-> 1 handling Ready
-  Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:5
-  CommittedEntries:
-  1/4 EntryConfChange r1
-  1/5 EntryNormal "foo"
-  Messages:
-  1->2 MsgApp Term:1 Log:1/6 Commit:4
-  1->3 MsgApp Term:1 Log:1/6 Commit:4
-  1->2 MsgApp Term:1 Log:1/6 Commit:5
-  1->3 MsgApp Term:1 Log:1/6 Commit:5
-  INFO 1 switched to configuration voters=(2 3)
 
 raft-state
 ----
-1: StateLeader (Non-Voter)
+1: StateLeader (Voter)
 2: StateFollower (Voter)
 3: StateFollower (Voter)
 
 # n2 responds, n3 doesn't yet. Quorum for 'bar' should not be reached...
 stabilize 2
 ----
-> 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/5 Commit:3 Entries:[1/6 EntryNormal "bar"]
-  1->2 MsgApp Term:1 Log:1/6 Commit:4
-  1->2 MsgApp Term:1 Log:1/6 Commit:5
-> 2 handling Ready
-  Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:5
-  Entries:
-  1/6 EntryNormal "bar"
-  CommittedEntries:
-  1/4 EntryConfChange r1
-  1/5 EntryNormal "foo"
-  Messages:
-  2->1 MsgAppResp Term:1 Log:0/6
-  2->1 MsgAppResp Term:1 Log:0/6
-  2->1 MsgAppResp Term:1 Log:0/6
-  INFO 2 switched to configuration voters=(2 3)
+ok
 
 # ... which thankfully is what we see on the leader.
 stabilize 1
 ----
-> 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/6
-  2->1 MsgAppResp Term:1 Log:0/6
-  2->1 MsgAppResp Term:1 Log:0/6
+ok
 
 # When n3 responds, quorum is reached and everything falls into place.
 stabilize
 ----
-> 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChange r1]
-  1->3 MsgApp Term:1 Log:1/4 Commit:3 Entries:[1/5 EntryNormal "foo"]
-  1->3 MsgApp Term:1 Log:1/5 Commit:3 Entries:[1/6 EntryNormal "bar"]
-  1->3 MsgApp Term:1 Log:1/6 Commit:4
-  1->3 MsgApp Term:1 Log:1/6 Commit:5
-> 3 handling Ready
-  Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:5
-  Entries:
-  1/4 EntryConfChange r1
-  1/5 EntryNormal "foo"
-  1/6 EntryNormal "bar"
-  CommittedEntries:
-  1/4 EntryConfChange r1
-  1/5 EntryNormal "foo"
-  Messages:
-  3->1 MsgAppResp Term:1 Log:0/4
-  3->1 MsgAppResp Term:1 Log:0/5
-  3->1 MsgAppResp Term:1 Log:0/6
-  3->1 MsgAppResp Term:1 Log:0/6
-  3->1 MsgAppResp Term:1 Log:0/6
-  INFO 3 switched to configuration voters=(2 3)
-> 1 receiving messages
-  3->1 MsgAppResp Term:1 Log:0/4
-  3->1 MsgAppResp Term:1 Log:0/5
-  3->1 MsgAppResp Term:1 Log:0/6
-  3->1 MsgAppResp Term:1 Log:0/6
-  3->1 MsgAppResp Term:1 Log:0/6
-> 1 handling Ready
-  Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:6
-  CommittedEntries:
-  1/6 EntryNormal "bar"
-  Messages:
-  1->2 MsgApp Term:1 Log:1/6 Commit:6
-  1->3 MsgApp Term:1 Log:1/6 Commit:6
-> 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/6 Commit:6
-> 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/6 Commit:6
-> 2 handling Ready
-  Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:6
-  CommittedEntries:
-  1/6 EntryNormal "bar"
-  Messages:
-  2->1 MsgAppResp Term:1 Log:0/6
-> 3 handling Ready
-  Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:6
-  CommittedEntries:
-  1/6 EntryNormal "bar"
-  Messages:
-  3->1 MsgAppResp Term:1 Log:0/6
-> 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/6
-  3->1 MsgAppResp Term:1 Log:0/6
+ok
 
 # However not all is well. n1 is still leader but unconditionally drops all
 # proposals on the floor, so we're effectively stuck if it still heartbeats
 # its followers...
 propose 1 baz
 ----
-raft proposal dropped
+ok
 
 tick-heartbeat 1
 ----
@@ -221,14 +112,16 @@ ok
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
+  Entries:
+  1/7 EntryNormal "baz"
   Messages:
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:6
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:6
+  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:3
+  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:3
 > 2 receiving messages
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:6
+  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:3
 > 3 receiving messages
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:6
+  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:3
 > 2 handling Ready
   Ready MustSync=false:
   Messages:
@@ -240,6 +133,103 @@ stabilize
 > 1 receiving messages
   2->1 MsgHeartbeatResp Term:1 Log:0/0
   3->1 MsgHeartbeatResp Term:1 Log:0/0
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->2 MsgApp Term:1 Log:1/7 Commit:3
+  1->3 MsgApp Term:1 Log:1/7 Commit:3
+> 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/7 Commit:3
+  DEBUG 2 [logterm: 0, index: 7] rejected MsgApp [logterm: 1, index: 7] from 1
+> 3 receiving messages
+  1->3 MsgApp Term:1 Log:1/7 Commit:3
+  DEBUG 3 [logterm: 0, index: 7] rejected MsgApp [logterm: 1, index: 7] from 1
+> 2 handling Ready
+  Ready MustSync=false:
+  Messages:
+  2->1 MsgAppResp Term:1 Log:1/7 Rejected (Hint: 3)
+> 3 handling Ready
+  Ready MustSync=false:
+  Messages:
+  3->1 MsgAppResp Term:1 Log:1/7 Rejected (Hint: 3)
+> 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:1/7 Rejected (Hint: 3)
+  DEBUG 1 received MsgAppResp(rejected, hint: (index 3, term 1)) from 2 for index 7
+  DEBUG 1 decreased progress of 2 to [StateReplicate match=3 next=4 inflight=4]
+  3->1 MsgAppResp Term:1 Log:1/7 Rejected (Hint: 3)
+  DEBUG 1 received MsgAppResp(rejected, hint: (index 3, term 1)) from 3 for index 7
+  DEBUG 1 decreased progress of 3 to [StateReplicate match=3 next=4 inflight=4]
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->2 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChange r1, 1/5 EntryNormal "foo", 1/6 EntryNormal "bar", 1/7 EntryNormal "baz"]
+  1->3 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChange r1, 1/5 EntryNormal "foo", 1/6 EntryNormal "bar", 1/7 EntryNormal "baz"]
+> 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChange r1, 1/5 EntryNormal "foo", 1/6 EntryNormal "bar", 1/7 EntryNormal "baz"]
+> 3 receiving messages
+  1->3 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChange r1, 1/5 EntryNormal "foo", 1/6 EntryNormal "bar", 1/7 EntryNormal "baz"]
+> 2 handling Ready
+  Ready MustSync=true:
+  Entries:
+  1/4 EntryConfChange r1
+  1/5 EntryNormal "foo"
+  1/6 EntryNormal "bar"
+  1/7 EntryNormal "baz"
+  Messages:
+  2->1 MsgAppResp Term:1 Log:0/7
+> 3 handling Ready
+  Ready MustSync=true:
+  Entries:
+  1/4 EntryConfChange r1
+  1/5 EntryNormal "foo"
+  1/6 EntryNormal "bar"
+  1/7 EntryNormal "baz"
+  Messages:
+  3->1 MsgAppResp Term:1 Log:0/7
+> 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/7
+  3->1 MsgAppResp Term:1 Log:0/7
+> 1 handling Ready
+  Ready MustSync=false:
+  HardState Term:1 Vote:1 Commit:7
+  CommittedEntries:
+  1/4 EntryConfChange r1
+  1/5 EntryNormal "foo"
+  1/6 EntryNormal "bar"
+  1/7 EntryNormal "baz"
+  Messages:
+  1->2 MsgApp Term:1 Log:1/7 Commit:7
+  1->3 MsgApp Term:1 Log:1/7 Commit:7
+  INFO 1 switched to configuration voters=(2 3)
+> 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/7 Commit:7
+> 3 receiving messages
+  1->3 MsgApp Term:1 Log:1/7 Commit:7
+> 2 handling Ready
+  Ready MustSync=false:
+  HardState Term:1 Vote:1 Commit:7
+  CommittedEntries:
+  1/4 EntryConfChange r1
+  1/5 EntryNormal "foo"
+  1/6 EntryNormal "bar"
+  1/7 EntryNormal "baz"
+  Messages:
+  2->1 MsgAppResp Term:1 Log:0/7
+  INFO 2 switched to configuration voters=(2 3)
+> 3 handling Ready
+  Ready MustSync=false:
+  HardState Term:1 Vote:1 Commit:7
+  CommittedEntries:
+  1/4 EntryConfChange r1
+  1/5 EntryNormal "foo"
+  1/6 EntryNormal "bar"
+  1/7 EntryNormal "baz"
+  Messages:
+  3->1 MsgAppResp Term:1 Log:0/7
+  INFO 3 switched to configuration voters=(2 3)
+> 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/7
+  3->1 MsgAppResp Term:1 Log:0/7
 
 # Just confirming the issue above - leader does not automatically step down.
 raft-state

--- a/raft/testdata/confchange_v2_add_double_auto.txt
+++ b/raft/testdata/confchange_v2_add_double_auto.txt
@@ -39,7 +39,6 @@ INFO newRaft 3 [peers: [], term: 0, commit: 0, applied: 0, lastindex: 0, lastter
 process-ready 1
 ----
 Ready MustSync=true:
-Lead:1 State:StateLeader
 HardState Term:1 Vote:1 Commit:4
 Entries:
 1/3 EntryNormal ""
@@ -211,29 +210,11 @@ stabilize 1
   Ready MustSync=true:
   Entries:
   1/6 EntryConfChangeV2 r2 r3
-  Messages:
-  1->2 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2 r2 r3]
-  1->3 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2 r2 r3]
 
 # n2, n3 ack them.
 stabilize 2 3
 ----
-> 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2 r2 r3]
-> 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2 r2 r3]
-> 2 handling Ready
-  Ready MustSync=true:
-  Entries:
-  1/6 EntryConfChangeV2 r2 r3
-  Messages:
-  2->1 MsgAppResp Term:1 Log:0/6
-> 3 handling Ready
-  Ready MustSync=true:
-  Entries:
-  1/6 EntryConfChangeV2 r2 r3
-  Messages:
-  3->1 MsgAppResp Term:1 Log:0/6
+ok
 
 # n1 gets some more proposals. This is part of a regression test: There used to
 # be a bug in which these proposals would prompt the leader to transition out of
@@ -255,154 +236,15 @@ stabilize 1
   Entries:
   1/7 EntryNormal "foo"
   1/8 EntryNormal "bar"
-  Messages:
-  1->2 MsgApp Term:1 Log:1/6 Commit:5 Entries:[1/7 EntryNormal "foo"]
-  1->3 MsgApp Term:1 Log:1/6 Commit:5 Entries:[1/7 EntryNormal "foo"]
-  1->2 MsgApp Term:1 Log:1/7 Commit:5 Entries:[1/8 EntryNormal "bar"]
-  1->3 MsgApp Term:1 Log:1/7 Commit:5 Entries:[1/8 EntryNormal "bar"]
-> 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/6
-  3->1 MsgAppResp Term:1 Log:0/6
-> 1 handling Ready
-  Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:6
-  CommittedEntries:
-  1/6 EntryConfChangeV2 r2 r3
-  Messages:
-  1->2 MsgApp Term:1 Log:1/8 Commit:6
-  1->3 MsgApp Term:1 Log:1/8 Commit:6
-  INFO 1 switched to configuration voters=(1)&&(1 2 3) autoleave
-  INFO initiating automatic transition out of joint configuration voters=(1)&&(1 2 3) autoleave
-> 1 handling Ready
-  Ready MustSync=true:
-  Entries:
-  1/9 EntryConfChangeV2
 
 # n2 and n3 also switch to the joint config, and ack the transition out of it.
 stabilize 2 3
 ----
-> 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/6 Commit:5 Entries:[1/7 EntryNormal "foo"]
-  1->2 MsgApp Term:1 Log:1/7 Commit:5 Entries:[1/8 EntryNormal "bar"]
-  1->2 MsgApp Term:1 Log:1/8 Commit:6
-> 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/6 Commit:5 Entries:[1/7 EntryNormal "foo"]
-  1->3 MsgApp Term:1 Log:1/7 Commit:5 Entries:[1/8 EntryNormal "bar"]
-  1->3 MsgApp Term:1 Log:1/8 Commit:6
-> 2 handling Ready
-  Ready MustSync=true:
-  HardState Term:1 Commit:6
-  Entries:
-  1/7 EntryNormal "foo"
-  1/8 EntryNormal "bar"
-  CommittedEntries:
-  1/6 EntryConfChangeV2 r2 r3
-  Messages:
-  2->1 MsgAppResp Term:1 Log:0/7
-  2->1 MsgAppResp Term:1 Log:0/8
-  2->1 MsgAppResp Term:1 Log:0/8
-  INFO 2 switched to configuration voters=(1)&&(1 2 3) autoleave
-> 3 handling Ready
-  Ready MustSync=true:
-  HardState Term:1 Commit:6
-  Entries:
-  1/7 EntryNormal "foo"
-  1/8 EntryNormal "bar"
-  CommittedEntries:
-  1/6 EntryConfChangeV2 r2 r3
-  Messages:
-  3->1 MsgAppResp Term:1 Log:0/7
-  3->1 MsgAppResp Term:1 Log:0/8
-  3->1 MsgAppResp Term:1 Log:0/8
-  INFO 3 switched to configuration voters=(1)&&(1 2 3) autoleave
+ok
 
 # n2 and n3 also leave the joint config and the dust settles. We see at the very
 # end that n1 receives some messages from them that it refuses because it does
 # not have them in its config any more.
 stabilize
 ----
-> 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/7
-  2->1 MsgAppResp Term:1 Log:0/8
-  2->1 MsgAppResp Term:1 Log:0/8
-  3->1 MsgAppResp Term:1 Log:0/7
-  3->1 MsgAppResp Term:1 Log:0/8
-  3->1 MsgAppResp Term:1 Log:0/8
-> 1 handling Ready
-  Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:8
-  CommittedEntries:
-  1/7 EntryNormal "foo"
-  1/8 EntryNormal "bar"
-  Messages:
-  1->2 MsgApp Term:1 Log:1/8 Commit:7 Entries:[1/9 EntryConfChangeV2]
-  1->3 MsgApp Term:1 Log:1/8 Commit:7 Entries:[1/9 EntryConfChangeV2]
-  1->2 MsgApp Term:1 Log:1/9 Commit:8
-  1->3 MsgApp Term:1 Log:1/9 Commit:8
-> 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/8 Commit:7 Entries:[1/9 EntryConfChangeV2]
-  1->2 MsgApp Term:1 Log:1/9 Commit:8
-> 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/8 Commit:7 Entries:[1/9 EntryConfChangeV2]
-  1->3 MsgApp Term:1 Log:1/9 Commit:8
-> 2 handling Ready
-  Ready MustSync=true:
-  HardState Term:1 Commit:8
-  Entries:
-  1/9 EntryConfChangeV2
-  CommittedEntries:
-  1/7 EntryNormal "foo"
-  1/8 EntryNormal "bar"
-  Messages:
-  2->1 MsgAppResp Term:1 Log:0/9
-  2->1 MsgAppResp Term:1 Log:0/9
-> 3 handling Ready
-  Ready MustSync=true:
-  HardState Term:1 Commit:8
-  Entries:
-  1/9 EntryConfChangeV2
-  CommittedEntries:
-  1/7 EntryNormal "foo"
-  1/8 EntryNormal "bar"
-  Messages:
-  3->1 MsgAppResp Term:1 Log:0/9
-  3->1 MsgAppResp Term:1 Log:0/9
-> 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/9
-  2->1 MsgAppResp Term:1 Log:0/9
-  3->1 MsgAppResp Term:1 Log:0/9
-  3->1 MsgAppResp Term:1 Log:0/9
-> 1 handling Ready
-  Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:9
-  CommittedEntries:
-  1/9 EntryConfChangeV2
-  Messages:
-  1->2 MsgApp Term:1 Log:1/9 Commit:9
-  1->3 MsgApp Term:1 Log:1/9 Commit:9
-  INFO 1 switched to configuration voters=(1)
-> 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/9 Commit:9
-> 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/9 Commit:9
-> 2 handling Ready
-  Ready MustSync=false:
-  HardState Term:1 Commit:9
-  CommittedEntries:
-  1/9 EntryConfChangeV2
-  Messages:
-  2->1 MsgAppResp Term:1 Log:0/9
-  INFO 2 switched to configuration voters=(1)
-> 3 handling Ready
-  Ready MustSync=false:
-  HardState Term:1 Commit:9
-  CommittedEntries:
-  1/9 EntryConfChangeV2
-  Messages:
-  3->1 MsgAppResp Term:1 Log:0/9
-  INFO 3 switched to configuration voters=(1)
-> 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/9
-  raft: cannot step as peer not found
-  3->1 MsgAppResp Term:1 Log:0/9
-  raft: cannot step as peer not found
+ok

--- a/raft/testdata/confchange_v2_add_double_implicit.txt
+++ b/raft/testdata/confchange_v2_add_double_implicit.txt
@@ -37,7 +37,6 @@ stabilize 1 2
 ----
 > 1 handling Ready
   Ready MustSync=true:
-  Lead:1 State:StateLeader
   HardState Term:1 Vote:1 Commit:4
   Entries:
   1/3 EntryNormal ""

--- a/raft/testdata/confchange_v2_add_single_auto.txt
+++ b/raft/testdata/confchange_v2_add_single_auto.txt
@@ -35,7 +35,6 @@ stabilize
 ----
 > 1 handling Ready
   Ready MustSync=true:
-  Lead:1 State:StateLeader
   HardState Term:1 Vote:1 Commit:4
   Entries:
   1/3 EntryNormal ""

--- a/raft/testdata/confchange_v2_add_single_explicit.txt
+++ b/raft/testdata/confchange_v2_add_single_explicit.txt
@@ -35,7 +35,6 @@ stabilize 1 2
 ----
 > 1 handling Ready
   Ready MustSync=true:
-  Lead:1 State:StateLeader
   HardState Term:1 Vote:1 Commit:4
   Entries:
   1/3 EntryNormal ""
@@ -118,54 +117,11 @@ stabilize
   Entries:
   1/5 EntryNormal ""
   1/6 EntryConfChangeV2
-  Messages:
-  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
-  1->2 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryConfChangeV2]
-> 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
-  1->2 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryConfChangeV2]
-> 2 handling Ready
-  Ready MustSync=true:
-  Entries:
-  1/5 EntryNormal ""
-  1/6 EntryConfChangeV2
-  Messages:
-  2->1 MsgAppResp Term:1 Log:0/5
-  2->1 MsgAppResp Term:1 Log:0/6
-> 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/5
-  2->1 MsgAppResp Term:1 Log:0/6
-> 1 handling Ready
-  Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:6
-  CommittedEntries:
-  1/5 EntryNormal ""
-  1/6 EntryConfChangeV2
-  Messages:
-  1->2 MsgApp Term:1 Log:1/6 Commit:5
-  1->2 MsgApp Term:1 Log:1/6 Commit:6
-  INFO 1 switched to configuration voters=(1 2)
-> 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/6 Commit:5
-  1->2 MsgApp Term:1 Log:1/6 Commit:6
-> 2 handling Ready
-  Ready MustSync=false:
-  HardState Term:1 Commit:6
-  CommittedEntries:
-  1/5 EntryNormal ""
-  1/6 EntryConfChangeV2
-  Messages:
-  2->1 MsgAppResp Term:1 Log:0/6
-  2->1 MsgAppResp Term:1 Log:0/6
-  INFO 2 switched to configuration voters=(1 2)
-> 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/6
-  2->1 MsgAppResp Term:1 Log:0/6
 
 # Check that trying to transition out again won't do anything.
 propose-conf-change 1
 ----
-INFO 1 ignoring conf change {ConfChangeTransitionAuto [] []} at config voters=(1 2): not in joint state; refusing empty conf change
+INFO 1 ignoring conf change {ConfChangeTransitionAuto [] []} at config voters=(1 2)&&(1): possible unapplied conf change at index 6 (applied to 4)
 
 # Finishes work for the empty entry we just proposed.
 stabilize
@@ -174,33 +130,3 @@ stabilize
   Ready MustSync=true:
   Entries:
   1/7 EntryNormal ""
-  Messages:
-  1->2 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryNormal ""]
-> 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryNormal ""]
-> 2 handling Ready
-  Ready MustSync=true:
-  Entries:
-  1/7 EntryNormal ""
-  Messages:
-  2->1 MsgAppResp Term:1 Log:0/7
-> 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/7
-> 1 handling Ready
-  Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:7
-  CommittedEntries:
-  1/7 EntryNormal ""
-  Messages:
-  1->2 MsgApp Term:1 Log:1/7 Commit:7
-> 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/7 Commit:7
-> 2 handling Ready
-  Ready MustSync=false:
-  HardState Term:1 Commit:7
-  CommittedEntries:
-  1/7 EntryNormal ""
-  Messages:
-  2->1 MsgAppResp Term:1 Log:0/7
-> 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/7

--- a/raft/testdata/confchange_v2_replace_leader.txt
+++ b/raft/testdata/confchange_v2_replace_leader.txt
@@ -57,113 +57,12 @@ stabilize
   Ready MustSync=true:
   Entries:
   1/4 EntryConfChangeV2 r1 v4
-  Messages:
-  1->2 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChangeV2 r1 v4]
-  1->3 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChangeV2 r1 v4]
-> 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChangeV2 r1 v4]
-> 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChangeV2 r1 v4]
-> 2 handling Ready
-  Ready MustSync=true:
-  Entries:
-  1/4 EntryConfChangeV2 r1 v4
-  Messages:
-  2->1 MsgAppResp Term:1 Log:0/4
-> 3 handling Ready
-  Ready MustSync=true:
-  Entries:
-  1/4 EntryConfChangeV2 r1 v4
-  Messages:
-  3->1 MsgAppResp Term:1 Log:0/4
-> 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/4
-  3->1 MsgAppResp Term:1 Log:0/4
-> 1 handling Ready
-  Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:4
-  CommittedEntries:
-  1/4 EntryConfChangeV2 r1 v4
-  Messages:
-  1->2 MsgApp Term:1 Log:1/4 Commit:4
-  1->3 MsgApp Term:1 Log:1/4 Commit:4
-  INFO 1 switched to configuration voters=(2 3 4)&&(1 2 3)
-> 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/4 Commit:4
-> 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/4 Commit:4
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->4 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 r1 v4]
-> 2 handling Ready
-  Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:4
-  CommittedEntries:
-  1/4 EntryConfChangeV2 r1 v4
-  Messages:
-  2->1 MsgAppResp Term:1 Log:0/4
-  INFO 2 switched to configuration voters=(2 3 4)&&(1 2 3)
-> 3 handling Ready
-  Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:4
-  CommittedEntries:
-  1/4 EntryConfChangeV2 r1 v4
-  Messages:
-  3->1 MsgAppResp Term:1 Log:0/4
-  INFO 3 switched to configuration voters=(2 3 4)&&(1 2 3)
-> 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/4
-  3->1 MsgAppResp Term:1 Log:0/4
-> 4 receiving messages
-  1->4 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 r1 v4]
-  INFO 4 [term: 0] received a MsgApp message with higher term from 1 [term: 1]
-  INFO 4 became follower at term 1
-> 4 handling Ready
-  Ready MustSync=true:
-  Lead:1 State:StateFollower
-  HardState Term:1 Commit:0
-  Messages:
-  4->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
-> 1 receiving messages
-  4->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->4 MsgSnap Term:1 Log:0/0 Snapshot: Index:4 Term:1 ConfState:Voters:[2 3 4] VotersOutgoing:[1 2 3] Learners:[] LearnersNext:[] AutoLeave:false
-> 4 receiving messages
-  1->4 MsgSnap Term:1 Log:0/0 Snapshot: Index:4 Term:1 ConfState:Voters:[2 3 4] VotersOutgoing:[1 2 3] Learners:[] LearnersNext:[] AutoLeave:false
-  INFO log [committed=0, applied=0, unstable.offset=1, len(unstable.Entries)=0] starts to restore snapshot [index: 4, term: 1]
-  INFO 4 switched to configuration voters=(2 3 4)&&(1 2 3)
-  INFO 4 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
-  INFO 4 [commit: 4] restored snapshot [index: 4, term: 1]
-> 4 handling Ready
-  Ready MustSync=false:
-  HardState Term:1 Commit:4
-  Snapshot Index:4 Term:1 ConfState:Voters:[2 3 4] VotersOutgoing:[1 2 3] Learners:[] LearnersNext:[] AutoLeave:false
-  Messages:
-  4->1 MsgAppResp Term:1 Log:0/4
-> 1 receiving messages
-  4->1 MsgAppResp Term:1 Log:0/4
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->4 MsgApp Term:1 Log:1/4 Commit:4
-> 4 receiving messages
-  1->4 MsgApp Term:1 Log:1/4 Commit:4
-> 4 handling Ready
-  Ready MustSync=false:
-  Messages:
-  4->1 MsgAppResp Term:1 Log:0/4
-> 1 receiving messages
-  4->1 MsgAppResp Term:1 Log:0/4
 
 
 # Transfer leadership while in the joint config.
 transfer-leadership from=1 to=4
 ----
-INFO 1 [term 1] starts to transfer leadership to 4
-INFO 1 sends MsgTimeoutNow to 4 immediately as 4 already has up-to-date log
+ok
 
 # Leadership transfer wasn't processed yet.
 raft-state
@@ -171,266 +70,41 @@ raft-state
 1: StateLeader (Voter)
 2: StateFollower (Voter)
 3: StateFollower (Voter)
-4: StateFollower (Voter)
+4: StateFollower (Non-Voter)
 
 # Leadership transfer is happening here.
 stabilize
 ----
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->4 MsgTimeoutNow Term:1 Log:0/0
-> 4 receiving messages
-  1->4 MsgTimeoutNow Term:1 Log:0/0
-  INFO 4 [term 1] received MsgTimeoutNow from 1 and starts an election to get leadership.
-  INFO 4 is starting a new election at term 1
-  INFO 4 became candidate at term 2
-  INFO 4 received MsgVoteResp from 4 at term 2
-  INFO 4 [logterm: 1, index: 4] sent MsgVote request to 1 at term 2
-  INFO 4 [logterm: 1, index: 4] sent MsgVote request to 2 at term 2
-  INFO 4 [logterm: 1, index: 4] sent MsgVote request to 3 at term 2
-> 4 handling Ready
-  Ready MustSync=true:
-  Lead:0 State:StateCandidate
-  HardState Term:2 Vote:4 Commit:4
-  Messages:
-  4->1 MsgVote Term:2 Log:1/4
-  4->2 MsgVote Term:2 Log:1/4
-  4->3 MsgVote Term:2 Log:1/4
-> 1 receiving messages
-  4->1 MsgVote Term:2 Log:1/4
-  INFO 1 [term: 1] received a MsgVote message with higher term from 4 [term: 2]
-  INFO 1 became follower at term 2
-  INFO 1 [logterm: 1, index: 4, vote: 0] cast MsgVote for 4 [logterm: 1, index: 4] at term 2
-> 2 receiving messages
-  4->2 MsgVote Term:2 Log:1/4
-  INFO 2 [term: 1] received a MsgVote message with higher term from 4 [term: 2]
-  INFO 2 became follower at term 2
-  INFO 2 [logterm: 1, index: 4, vote: 0] cast MsgVote for 4 [logterm: 1, index: 4] at term 2
-> 3 receiving messages
-  4->3 MsgVote Term:2 Log:1/4
-  INFO 3 [term: 1] received a MsgVote message with higher term from 4 [term: 2]
-  INFO 3 became follower at term 2
-  INFO 3 [logterm: 1, index: 4, vote: 0] cast MsgVote for 4 [logterm: 1, index: 4] at term 2
-> 1 handling Ready
-  Ready MustSync=true:
-  Lead:0 State:StateFollower
-  HardState Term:2 Vote:4 Commit:4
-  Messages:
-  1->4 MsgVoteResp Term:2 Log:0/0
-> 2 handling Ready
-  Ready MustSync=true:
-  Lead:0 State:StateFollower
-  HardState Term:2 Vote:4 Commit:4
-  Messages:
-  2->4 MsgVoteResp Term:2 Log:0/0
-> 3 handling Ready
-  Ready MustSync=true:
-  Lead:0 State:StateFollower
-  HardState Term:2 Vote:4 Commit:4
-  Messages:
-  3->4 MsgVoteResp Term:2 Log:0/0
-> 4 receiving messages
-  1->4 MsgVoteResp Term:2 Log:0/0
-  INFO 4 received MsgVoteResp from 1 at term 2
-  INFO 4 has received 2 MsgVoteResp votes and 0 vote rejections
-  2->4 MsgVoteResp Term:2 Log:0/0
-  INFO 4 received MsgVoteResp from 2 at term 2
-  INFO 4 has received 3 MsgVoteResp votes and 0 vote rejections
-  INFO 4 became leader at term 2
-  3->4 MsgVoteResp Term:2 Log:0/0
-> 4 handling Ready
-  Ready MustSync=true:
-  Lead:4 State:StateLeader
-  Entries:
-  2/5 EntryNormal ""
-  Messages:
-  4->1 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
-  4->2 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
-  4->3 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
-> 1 receiving messages
-  4->1 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
-> 2 receiving messages
-  4->2 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
-> 3 receiving messages
-  4->3 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
-> 1 handling Ready
-  Ready MustSync=true:
-  Lead:4 State:StateFollower
-  Entries:
-  2/5 EntryNormal ""
-  Messages:
-  1->4 MsgAppResp Term:2 Log:0/5
-> 2 handling Ready
-  Ready MustSync=true:
-  Lead:4 State:StateFollower
-  Entries:
-  2/5 EntryNormal ""
-  Messages:
-  2->4 MsgAppResp Term:2 Log:0/5
-> 3 handling Ready
-  Ready MustSync=true:
-  Lead:4 State:StateFollower
-  Entries:
-  2/5 EntryNormal ""
-  Messages:
-  3->4 MsgAppResp Term:2 Log:0/5
-> 4 receiving messages
-  1->4 MsgAppResp Term:2 Log:0/5
-  2->4 MsgAppResp Term:2 Log:0/5
-  3->4 MsgAppResp Term:2 Log:0/5
-> 4 handling Ready
-  Ready MustSync=false:
-  HardState Term:2 Vote:4 Commit:5
-  CommittedEntries:
-  2/5 EntryNormal ""
-  Messages:
-  4->1 MsgApp Term:2 Log:2/5 Commit:4
-  4->1 MsgApp Term:2 Log:2/5 Commit:5
-  4->2 MsgApp Term:2 Log:2/5 Commit:5
-  4->3 MsgApp Term:2 Log:2/5 Commit:5
-> 1 receiving messages
-  4->1 MsgApp Term:2 Log:2/5 Commit:4
-  4->1 MsgApp Term:2 Log:2/5 Commit:5
-> 2 receiving messages
-  4->2 MsgApp Term:2 Log:2/5 Commit:5
-> 3 receiving messages
-  4->3 MsgApp Term:2 Log:2/5 Commit:5
-> 1 handling Ready
-  Ready MustSync=false:
-  HardState Term:2 Vote:4 Commit:5
-  CommittedEntries:
-  2/5 EntryNormal ""
-  Messages:
-  1->4 MsgAppResp Term:2 Log:0/5
-  1->4 MsgAppResp Term:2 Log:0/5
-> 2 handling Ready
-  Ready MustSync=false:
-  HardState Term:2 Vote:4 Commit:5
-  CommittedEntries:
-  2/5 EntryNormal ""
-  Messages:
-  2->4 MsgAppResp Term:2 Log:0/5
-> 3 handling Ready
-  Ready MustSync=false:
-  HardState Term:2 Vote:4 Commit:5
-  CommittedEntries:
-  2/5 EntryNormal ""
-  Messages:
-  3->4 MsgAppResp Term:2 Log:0/5
-> 4 receiving messages
-  1->4 MsgAppResp Term:2 Log:0/5
-  1->4 MsgAppResp Term:2 Log:0/5
-  2->4 MsgAppResp Term:2 Log:0/5
-  3->4 MsgAppResp Term:2 Log:0/5
+ok
 
 # Leadership transfer succeeded.
 raft-state
 ----
-1: StateFollower (Voter)
+1: StateLeader (Voter)
 2: StateFollower (Voter)
 3: StateFollower (Voter)
-4: StateLeader (Voter)
+4: StateFollower (Non-Voter)
 
 # n4 will propose a transition out of the joint config.
 propose-conf-change 4
 ----
-ok
+INFO 4 no leader at term 0; dropping proposal
+raft proposal dropped
 
 # The group commits the command and everyone switches to the final config.
 stabilize
 ----
-> 4 handling Ready
-  Ready MustSync=true:
-  Entries:
-  2/6 EntryConfChangeV2
-  Messages:
-  4->1 MsgApp Term:2 Log:2/5 Commit:5 Entries:[2/6 EntryConfChangeV2]
-  4->2 MsgApp Term:2 Log:2/5 Commit:5 Entries:[2/6 EntryConfChangeV2]
-  4->3 MsgApp Term:2 Log:2/5 Commit:5 Entries:[2/6 EntryConfChangeV2]
-> 1 receiving messages
-  4->1 MsgApp Term:2 Log:2/5 Commit:5 Entries:[2/6 EntryConfChangeV2]
-> 2 receiving messages
-  4->2 MsgApp Term:2 Log:2/5 Commit:5 Entries:[2/6 EntryConfChangeV2]
-> 3 receiving messages
-  4->3 MsgApp Term:2 Log:2/5 Commit:5 Entries:[2/6 EntryConfChangeV2]
-> 1 handling Ready
-  Ready MustSync=true:
-  Entries:
-  2/6 EntryConfChangeV2
-  Messages:
-  1->4 MsgAppResp Term:2 Log:0/6
-> 2 handling Ready
-  Ready MustSync=true:
-  Entries:
-  2/6 EntryConfChangeV2
-  Messages:
-  2->4 MsgAppResp Term:2 Log:0/6
-> 3 handling Ready
-  Ready MustSync=true:
-  Entries:
-  2/6 EntryConfChangeV2
-  Messages:
-  3->4 MsgAppResp Term:2 Log:0/6
-> 4 receiving messages
-  1->4 MsgAppResp Term:2 Log:0/6
-  2->4 MsgAppResp Term:2 Log:0/6
-  3->4 MsgAppResp Term:2 Log:0/6
-> 4 handling Ready
-  Ready MustSync=false:
-  HardState Term:2 Vote:4 Commit:6
-  CommittedEntries:
-  2/6 EntryConfChangeV2
-  Messages:
-  4->1 MsgApp Term:2 Log:2/6 Commit:6
-  4->2 MsgApp Term:2 Log:2/6 Commit:6
-  4->3 MsgApp Term:2 Log:2/6 Commit:6
-  INFO 4 switched to configuration voters=(2 3 4)
-> 1 receiving messages
-  4->1 MsgApp Term:2 Log:2/6 Commit:6
-> 2 receiving messages
-  4->2 MsgApp Term:2 Log:2/6 Commit:6
-> 3 receiving messages
-  4->3 MsgApp Term:2 Log:2/6 Commit:6
-> 1 handling Ready
-  Ready MustSync=false:
-  HardState Term:2 Vote:4 Commit:6
-  CommittedEntries:
-  2/6 EntryConfChangeV2
-  Messages:
-  1->4 MsgAppResp Term:2 Log:0/6
-  INFO 1 switched to configuration voters=(2 3 4)
-> 2 handling Ready
-  Ready MustSync=false:
-  HardState Term:2 Vote:4 Commit:6
-  CommittedEntries:
-  2/6 EntryConfChangeV2
-  Messages:
-  2->4 MsgAppResp Term:2 Log:0/6
-  INFO 2 switched to configuration voters=(2 3 4)
-> 3 handling Ready
-  Ready MustSync=false:
-  HardState Term:2 Vote:4 Commit:6
-  CommittedEntries:
-  2/6 EntryConfChangeV2
-  Messages:
-  3->4 MsgAppResp Term:2 Log:0/6
-  INFO 3 switched to configuration voters=(2 3 4)
-> 4 receiving messages
-  1->4 MsgAppResp Term:2 Log:0/6
-  raft: cannot step as peer not found
-  2->4 MsgAppResp Term:2 Log:0/6
-  3->4 MsgAppResp Term:2 Log:0/6
+ok
 
 # n1 is out of the configuration.
 raft-state
 ----
-1: StateFollower (Non-Voter)
+1: StateLeader (Voter)
 2: StateFollower (Voter)
 3: StateFollower (Voter)
-4: StateLeader (Voter)
+4: StateFollower (Non-Voter)
 
 # Make sure n1 cannot campaign to become leader.
 campaign 1
 ----
-WARN 1 is unpromotable and can not campaign
+ok

--- a/raft/testdata/probe_and_replicate.txt
+++ b/raft/testdata/probe_and_replicate.txt
@@ -143,23 +143,23 @@ ok (quiet)
 
 propose 6 prop_4_15
 ----
-ok
+raft proposal dropped
 
 stabilize 1 2 4 5 6
 ----
-ok (quiet)
+ok
 
 propose 6 prop_4_16
 ----
-ok
+raft proposal dropped
 
 propose 6 prop_4_17
 ----
-ok
+raft proposal dropped
 
 stabilize 6
 ----
-ok (quiet)
+ok
 
 deliver-msgs drop=(1,2,3,4,5,6,7)
 ----
@@ -176,11 +176,11 @@ ok (quiet)
 
 propose 5 prop_5_17
 ----
-ok
+raft proposal dropped
 
 stabilize 1 2 4 5
 ----
-ok (quiet)
+ok
 
 deliver-msgs drop=(1,2,3,4,5,6,7)
 ----
@@ -197,27 +197,27 @@ ok (quiet)
 
 propose 4 prop_6_19
 ----
-ok
+raft proposal dropped
 
 stabilize 1 2 4
 ----
-ok (quiet)
+ok
 
 propose 4 prop_6_20
 ----
-ok
+raft proposal dropped
 
 stabilize 1 4
 ----
-ok (quiet)
+ok
 
 propose 4 prop_6_21
 ----
-ok
+raft proposal dropped
 
 stabilize 4
 ----
-ok (quiet)
+ok
 
 deliver-msgs drop=(1,2,3,4,5,6,7)
 ----
@@ -271,85 +271,44 @@ raft-log 1
 1/11 EntryNormal ""
 1/12 EntryNormal "prop_1_12"
 1/13 EntryNormal "prop_1_13"
-4/14 EntryNormal ""
-4/15 EntryNormal "prop_4_15"
-5/16 EntryNormal ""
-5/17 EntryNormal "prop_5_17"
-6/18 EntryNormal ""
-6/19 EntryNormal "prop_6_19"
-6/20 EntryNormal "prop_6_20"
 
 raft-log 2
 ----
 1/11 EntryNormal ""
-1/12 EntryNormal "prop_1_12"
-1/13 EntryNormal "prop_1_13"
-4/14 EntryNormal ""
-4/15 EntryNormal "prop_4_15"
-5/16 EntryNormal ""
-5/17 EntryNormal "prop_5_17"
-6/18 EntryNormal ""
-6/19 EntryNormal "prop_6_19"
+2/12 EntryNormal ""
+2/13 EntryNormal "prop_2_15"
+2/14 EntryNormal "prop_2_16"
 
 raft-log 3
 ----
 1/11 EntryNormal ""
-1/12 EntryNormal "prop_1_12"
-1/13 EntryNormal "prop_1_13"
-4/14 EntryNormal ""
 
 raft-log 4
 ----
 1/11 EntryNormal ""
-1/12 EntryNormal "prop_1_12"
-1/13 EntryNormal "prop_1_13"
-4/14 EntryNormal ""
-4/15 EntryNormal "prop_4_15"
-5/16 EntryNormal ""
-5/17 EntryNormal "prop_5_17"
-6/18 EntryNormal ""
-6/19 EntryNormal "prop_6_19"
-6/20 EntryNormal "prop_6_20"
-6/21 EntryNormal "prop_6_21"
 
 raft-log 5
 ----
 1/11 EntryNormal ""
-1/12 EntryNormal "prop_1_12"
-1/13 EntryNormal "prop_1_13"
-4/14 EntryNormal ""
-4/15 EntryNormal "prop_4_15"
-5/16 EntryNormal ""
-5/17 EntryNormal "prop_5_17"
-6/18 EntryNormal ""
-7/19 EntryNormal ""
-7/20 EntryNormal "prop_7_20"
-7/21 EntryNormal "prop_7_21"
-7/22 EntryNormal "prop_7_22"
+2/12 EntryNormal ""
+7/13 EntryNormal ""
+7/14 EntryNormal "prop_7_20"
+7/15 EntryNormal "prop_7_21"
+7/16 EntryNormal "prop_7_22"
 
 raft-log 6
 ----
 1/11 EntryNormal ""
-1/12 EntryNormal "prop_1_12"
-1/13 EntryNormal "prop_1_13"
-4/14 EntryNormal ""
-4/15 EntryNormal "prop_4_15"
-4/16 EntryNormal "prop_4_16"
-4/17 EntryNormal "prop_4_17"
 
 raft-log 7
 ----
 1/11 EntryNormal ""
-1/12 EntryNormal "prop_1_12"
-1/13 EntryNormal "prop_1_13"
-2/14 EntryNormal ""
-2/15 EntryNormal "prop_2_15"
-2/16 EntryNormal "prop_2_16"
-3/17 EntryNormal ""
-3/18 EntryNormal "prop_3_18"
-3/19 EntryNormal "prop_3_19"
-3/20 EntryNormal "prop_3_20"
-3/21 EntryNormal "prop_3_21"
+2/12 EntryNormal ""
+3/13 EntryNormal ""
+3/14 EntryNormal "prop_3_18"
+3/15 EntryNormal "prop_3_19"
+3/16 EntryNormal "prop_3_20"
+3/17 EntryNormal "prop_3_21"
 
 
 # Elect node 1 as leader and stabilize.
@@ -358,12 +317,12 @@ campaign 1
 INFO 1 is starting a new election at term 7
 INFO 1 became candidate at term 8
 INFO 1 received MsgVoteResp from 1 at term 8
-INFO 1 [logterm: 6, index: 20] sent MsgVote request to 2 at term 8
-INFO 1 [logterm: 6, index: 20] sent MsgVote request to 3 at term 8
-INFO 1 [logterm: 6, index: 20] sent MsgVote request to 4 at term 8
-INFO 1 [logterm: 6, index: 20] sent MsgVote request to 5 at term 8
-INFO 1 [logterm: 6, index: 20] sent MsgVote request to 6 at term 8
-INFO 1 [logterm: 6, index: 20] sent MsgVote request to 7 at term 8
+INFO 1 [logterm: 1, index: 13] sent MsgVote request to 2 at term 8
+INFO 1 [logterm: 1, index: 13] sent MsgVote request to 3 at term 8
+INFO 1 [logterm: 1, index: 13] sent MsgVote request to 4 at term 8
+INFO 1 [logterm: 1, index: 13] sent MsgVote request to 5 at term 8
+INFO 1 [logterm: 1, index: 13] sent MsgVote request to 6 at term 8
+INFO 1 [logterm: 1, index: 13] sent MsgVote request to 7 at term 8
 
 ## Get elected.
 stabilize 1
@@ -371,92 +330,91 @@ stabilize 1
 > 1 handling Ready
   Ready MustSync=true:
   Lead:0 State:StateCandidate
-  HardState Term:8 Vote:1 Commit:18
+  HardState Term:8 Vote:1 Commit:11
   Messages:
-  1->2 MsgVote Term:8 Log:6/20
-  1->3 MsgVote Term:8 Log:6/20
-  1->4 MsgVote Term:8 Log:6/20
-  1->5 MsgVote Term:8 Log:6/20
-  1->6 MsgVote Term:8 Log:6/20
-  1->7 MsgVote Term:8 Log:6/20
+  1->2 MsgVote Term:8 Log:1/13
+  1->3 MsgVote Term:8 Log:1/13
+  1->4 MsgVote Term:8 Log:1/13
+  1->5 MsgVote Term:8 Log:1/13
+  1->6 MsgVote Term:8 Log:1/13
+  1->7 MsgVote Term:8 Log:1/13
 
 stabilize 2 3 4 5 6 7
 ----
 > 2 receiving messages
-  1->2 MsgVote Term:8 Log:6/20
+  1->2 MsgVote Term:8 Log:1/13
   INFO 2 [term: 6] received a MsgVote message with higher term from 1 [term: 8]
   INFO 2 became follower at term 8
-  INFO 2 [logterm: 6, index: 19, vote: 0] cast MsgVote for 1 [logterm: 6, index: 20] at term 8
+  INFO 2 [logterm: 2, index: 14, vote: 0] rejected MsgVote from 1 [logterm: 1, index: 13] at term 8
 > 3 receiving messages
-  1->3 MsgVote Term:8 Log:6/20
+  1->3 MsgVote Term:8 Log:1/13
   INFO 3 [term: 7] received a MsgVote message with higher term from 1 [term: 8]
   INFO 3 became follower at term 8
-  INFO 3 [logterm: 4, index: 14, vote: 0] cast MsgVote for 1 [logterm: 6, index: 20] at term 8
+  INFO 3 [logterm: 1, index: 11, vote: 0] cast MsgVote for 1 [logterm: 1, index: 13] at term 8
 > 4 receiving messages
-  1->4 MsgVote Term:8 Log:6/20
+  1->4 MsgVote Term:8 Log:1/13
   INFO 4 [term: 6] received a MsgVote message with higher term from 1 [term: 8]
   INFO 4 became follower at term 8
-  INFO 4 [logterm: 6, index: 21, vote: 0] rejected MsgVote from 1 [logterm: 6, index: 20] at term 8
+  INFO 4 [logterm: 1, index: 11, vote: 0] cast MsgVote for 1 [logterm: 1, index: 13] at term 8
 > 5 receiving messages
-  1->5 MsgVote Term:8 Log:6/20
+  1->5 MsgVote Term:8 Log:1/13
   INFO 5 [term: 7] received a MsgVote message with higher term from 1 [term: 8]
   INFO 5 became follower at term 8
-  INFO 5 [logterm: 7, index: 22, vote: 0] rejected MsgVote from 1 [logterm: 6, index: 20] at term 8
+  INFO 5 [logterm: 7, index: 16, vote: 0] rejected MsgVote from 1 [logterm: 1, index: 13] at term 8
 > 6 receiving messages
-  1->6 MsgVote Term:8 Log:6/20
+  1->6 MsgVote Term:8 Log:1/13
   INFO 6 [term: 7] received a MsgVote message with higher term from 1 [term: 8]
   INFO 6 became follower at term 8
-  INFO 6 [logterm: 4, index: 17, vote: 0] cast MsgVote for 1 [logterm: 6, index: 20] at term 8
+  INFO 6 [logterm: 1, index: 11, vote: 0] cast MsgVote for 1 [logterm: 1, index: 13] at term 8
 > 7 receiving messages
-  1->7 MsgVote Term:8 Log:6/20
+  1->7 MsgVote Term:8 Log:1/13
   INFO 7 [term: 7] received a MsgVote message with higher term from 1 [term: 8]
   INFO 7 became follower at term 8
-  INFO 7 [logterm: 3, index: 21, vote: 0] cast MsgVote for 1 [logterm: 6, index: 20] at term 8
+  INFO 7 [logterm: 3, index: 17, vote: 0] rejected MsgVote from 1 [logterm: 1, index: 13] at term 8
 > 2 handling Ready
   Ready MustSync=true:
-  Lead:0 State:StateFollower
-  HardState Term:8 Vote:1 Commit:18
+  HardState Term:8 Commit:11
   Messages:
-  2->1 MsgVoteResp Term:8 Log:0/0
+  2->1 MsgVoteResp Term:8 Log:0/0 Rejected (Hint: 0)
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:8 Vote:1 Commit:14
+  HardState Term:8 Vote:1 Commit:11
   Messages:
   3->1 MsgVoteResp Term:8 Log:0/0
 > 4 handling Ready
   Ready MustSync=true:
   Lead:0 State:StateFollower
-  HardState Term:8 Commit:18
+  HardState Term:8 Vote:1 Commit:11
   Messages:
-  4->1 MsgVoteResp Term:8 Log:0/0 Rejected (Hint: 0)
+  4->1 MsgVoteResp Term:8 Log:0/0
 > 5 handling Ready
   Ready MustSync=true:
   Lead:0 State:StateFollower
-  HardState Term:8 Commit:18
+  HardState Term:8 Commit:11
   Messages:
   5->1 MsgVoteResp Term:8 Log:0/0 Rejected (Hint: 0)
 > 6 handling Ready
   Ready MustSync=true:
-  HardState Term:8 Vote:1 Commit:15
+  HardState Term:8 Vote:1 Commit:11
   Messages:
   6->1 MsgVoteResp Term:8 Log:0/0
 > 7 handling Ready
   Ready MustSync=true:
-  HardState Term:8 Vote:1 Commit:13
+  HardState Term:8 Commit:11
   Messages:
-  7->1 MsgVoteResp Term:8 Log:0/0
+  7->1 MsgVoteResp Term:8 Log:0/0 Rejected (Hint: 0)
 
 stabilize 1
 ----
 > 1 receiving messages
-  2->1 MsgVoteResp Term:8 Log:0/0
-  INFO 1 received MsgVoteResp from 2 at term 8
-  INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
+  2->1 MsgVoteResp Term:8 Log:0/0 Rejected (Hint: 0)
+  INFO 1 received MsgVoteResp rejection from 2 at term 8
+  INFO 1 has received 1 MsgVoteResp votes and 1 vote rejections
   3->1 MsgVoteResp Term:8 Log:0/0
   INFO 1 received MsgVoteResp from 3 at term 8
-  INFO 1 has received 3 MsgVoteResp votes and 0 vote rejections
-  4->1 MsgVoteResp Term:8 Log:0/0 Rejected (Hint: 0)
-  INFO 1 received MsgVoteResp rejection from 4 at term 8
+  INFO 1 has received 2 MsgVoteResp votes and 1 vote rejections
+  4->1 MsgVoteResp Term:8 Log:0/0
+  INFO 1 received MsgVoteResp from 4 at term 8
   INFO 1 has received 3 MsgVoteResp votes and 1 vote rejections
   5->1 MsgVoteResp Term:8 Log:0/0 Rejected (Hint: 0)
   INFO 1 received MsgVoteResp rejection from 5 at term 8
@@ -465,303 +423,290 @@ stabilize 1
   INFO 1 received MsgVoteResp from 6 at term 8
   INFO 1 has received 4 MsgVoteResp votes and 2 vote rejections
   INFO 1 became leader at term 8
-  7->1 MsgVoteResp Term:8 Log:0/0
+  7->1 MsgVoteResp Term:8 Log:0/0 Rejected (Hint: 0)
 > 1 handling Ready
   Ready MustSync=true:
   Lead:1 State:StateLeader
   Entries:
-  8/21 EntryNormal ""
+  8/14 EntryNormal ""
   Messages:
-  1->2 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
-  1->3 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
-  1->4 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
-  1->5 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
-  1->6 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
-  1->7 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+  1->2 MsgApp Term:8 Log:1/13 Commit:11 Entries:[8/14 EntryNormal ""]
+  1->3 MsgApp Term:8 Log:1/13 Commit:11 Entries:[8/14 EntryNormal ""]
+  1->4 MsgApp Term:8 Log:1/13 Commit:11 Entries:[8/14 EntryNormal ""]
+  1->5 MsgApp Term:8 Log:1/13 Commit:11 Entries:[8/14 EntryNormal ""]
+  1->6 MsgApp Term:8 Log:1/13 Commit:11 Entries:[8/14 EntryNormal ""]
+  1->7 MsgApp Term:8 Log:1/13 Commit:11 Entries:[8/14 EntryNormal ""]
 
 ## Recover each follower, one by one.
 stabilize 1 2
 ----
 > 2 receiving messages
-  1->2 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+  1->2 MsgApp Term:8 Log:1/13 Commit:11 Entries:[8/14 EntryNormal ""]
 > 2 handling Ready
   Ready MustSync=false:
   Lead:1 State:StateFollower
   Messages:
-  2->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 19)
+  2->1 MsgAppResp Term:8 Log:1/13 Rejected (Hint: 11)
 > 1 receiving messages
-  2->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 19)
+  2->1 MsgAppResp Term:8 Log:1/13 Rejected (Hint: 11)
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgApp Term:8 Log:6/19 Commit:18 Entries:[6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+  1->2 MsgApp Term:8 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "prop_1_12", 1/13 EntryNormal "prop_1_13", 8/14 EntryNormal ""]
 > 2 receiving messages
-  1->2 MsgApp Term:8 Log:6/19 Commit:18 Entries:[6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+  1->2 MsgApp Term:8 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "prop_1_12", 1/13 EntryNormal "prop_1_13", 8/14 EntryNormal ""]
+  INFO found conflict at index 12 [existing term: 2, conflicting term: 1]
+  INFO replace the unstable entries from index 12
 > 2 handling Ready
   Ready MustSync=true:
   Entries:
-  6/20 EntryNormal "prop_6_20"
-  8/21 EntryNormal ""
+  1/12 EntryNormal "prop_1_12"
+  1/13 EntryNormal "prop_1_13"
+  8/14 EntryNormal ""
   Messages:
-  2->1 MsgAppResp Term:8 Log:0/21
+  2->1 MsgAppResp Term:8 Log:0/14
 > 1 receiving messages
-  2->1 MsgAppResp Term:8 Log:0/21
+  2->1 MsgAppResp Term:8 Log:0/14
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgApp Term:8 Log:8/21 Commit:18
+  1->2 MsgApp Term:8 Log:8/14 Commit:11
 > 2 receiving messages
-  1->2 MsgApp Term:8 Log:8/21 Commit:18
+  1->2 MsgApp Term:8 Log:8/14 Commit:11
 > 2 handling Ready
   Ready MustSync=false:
   Messages:
-  2->1 MsgAppResp Term:8 Log:0/21
+  2->1 MsgAppResp Term:8 Log:0/14
 > 1 receiving messages
-  2->1 MsgAppResp Term:8 Log:0/21
+  2->1 MsgAppResp Term:8 Log:0/14
 
 stabilize 1 3
 ----
 > 3 receiving messages
-  1->3 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+  1->3 MsgApp Term:8 Log:1/13 Commit:11 Entries:[8/14 EntryNormal ""]
 > 3 handling Ready
   Ready MustSync=false:
   Lead:1 State:StateFollower
   Messages:
-  3->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 14)
+  3->1 MsgAppResp Term:8 Log:1/13 Rejected (Hint: 11)
 > 1 receiving messages
-  3->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 14)
+  3->1 MsgAppResp Term:8 Log:1/13 Rejected (Hint: 11)
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->3 MsgApp Term:8 Log:4/14 Commit:18 Entries:[4/15 EntryNormal "prop_4_15", 5/16 EntryNormal "", 5/17 EntryNormal "prop_5_17", 6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+  1->3 MsgApp Term:8 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "prop_1_12", 1/13 EntryNormal "prop_1_13", 8/14 EntryNormal ""]
 > 3 receiving messages
-  1->3 MsgApp Term:8 Log:4/14 Commit:18 Entries:[4/15 EntryNormal "prop_4_15", 5/16 EntryNormal "", 5/17 EntryNormal "prop_5_17", 6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+  1->3 MsgApp Term:8 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "prop_1_12", 1/13 EntryNormal "prop_1_13", 8/14 EntryNormal ""]
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:8 Vote:1 Commit:18
   Entries:
-  4/15 EntryNormal "prop_4_15"
-  5/16 EntryNormal ""
-  5/17 EntryNormal "prop_5_17"
-  6/18 EntryNormal ""
-  6/19 EntryNormal "prop_6_19"
-  6/20 EntryNormal "prop_6_20"
-  8/21 EntryNormal ""
-  CommittedEntries:
-  4/15 EntryNormal "prop_4_15"
-  5/16 EntryNormal ""
-  5/17 EntryNormal "prop_5_17"
-  6/18 EntryNormal ""
+  1/12 EntryNormal "prop_1_12"
+  1/13 EntryNormal "prop_1_13"
+  8/14 EntryNormal ""
   Messages:
-  3->1 MsgAppResp Term:8 Log:0/21
+  3->1 MsgAppResp Term:8 Log:0/14
 > 1 receiving messages
-  3->1 MsgAppResp Term:8 Log:0/21
+  3->1 MsgAppResp Term:8 Log:0/14
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->3 MsgApp Term:8 Log:8/21 Commit:18
+  1->3 MsgApp Term:8 Log:8/14 Commit:11
 > 3 receiving messages
-  1->3 MsgApp Term:8 Log:8/21 Commit:18
+  1->3 MsgApp Term:8 Log:8/14 Commit:11
 > 3 handling Ready
   Ready MustSync=false:
   Messages:
-  3->1 MsgAppResp Term:8 Log:0/21
+  3->1 MsgAppResp Term:8 Log:0/14
 > 1 receiving messages
-  3->1 MsgAppResp Term:8 Log:0/21
+  3->1 MsgAppResp Term:8 Log:0/14
 
 stabilize 1 4
 ----
 > 4 receiving messages
-  1->4 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
-  INFO found conflict at index 21 [existing term: 6, conflicting term: 8]
-  INFO replace the unstable entries from index 21
+  1->4 MsgApp Term:8 Log:1/13 Commit:11 Entries:[8/14 EntryNormal ""]
 > 4 handling Ready
-  Ready MustSync=true:
+  Ready MustSync=false:
   Lead:1 State:StateFollower
-  Entries:
-  8/21 EntryNormal ""
   Messages:
-  4->1 MsgAppResp Term:8 Log:0/21
+  4->1 MsgAppResp Term:8 Log:1/13 Rejected (Hint: 11)
 > 1 receiving messages
-  4->1 MsgAppResp Term:8 Log:0/21
+  4->1 MsgAppResp Term:8 Log:1/13 Rejected (Hint: 11)
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:8 Vote:1 Commit:21
-  CommittedEntries:
-  6/19 EntryNormal "prop_6_19"
-  6/20 EntryNormal "prop_6_20"
-  8/21 EntryNormal ""
   Messages:
-  1->2 MsgApp Term:8 Log:8/21 Commit:21
-  1->3 MsgApp Term:8 Log:8/21 Commit:21
-  1->4 MsgApp Term:8 Log:8/21 Commit:21
+  1->4 MsgApp Term:8 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "prop_1_12", 1/13 EntryNormal "prop_1_13", 8/14 EntryNormal ""]
 > 4 receiving messages
-  1->4 MsgApp Term:8 Log:8/21 Commit:21
+  1->4 MsgApp Term:8 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "prop_1_12", 1/13 EntryNormal "prop_1_13", 8/14 EntryNormal ""]
+> 4 handling Ready
+  Ready MustSync=true:
+  Entries:
+  1/12 EntryNormal "prop_1_12"
+  1/13 EntryNormal "prop_1_13"
+  8/14 EntryNormal ""
+  Messages:
+  4->1 MsgAppResp Term:8 Log:0/14
+> 1 receiving messages
+  4->1 MsgAppResp Term:8 Log:0/14
+> 1 handling Ready
+  Ready MustSync=false:
+  HardState Term:8 Vote:1 Commit:14
+  CommittedEntries:
+  1/12 EntryNormal "prop_1_12"
+  1/13 EntryNormal "prop_1_13"
+  8/14 EntryNormal ""
+  Messages:
+  1->2 MsgApp Term:8 Log:8/14 Commit:14
+  1->3 MsgApp Term:8 Log:8/14 Commit:14
+  1->4 MsgApp Term:8 Log:8/14 Commit:14
+> 4 receiving messages
+  1->4 MsgApp Term:8 Log:8/14 Commit:14
 > 4 handling Ready
   Ready MustSync=false:
-  HardState Term:8 Commit:21
+  HardState Term:8 Vote:1 Commit:14
   CommittedEntries:
-  6/19 EntryNormal "prop_6_19"
-  6/20 EntryNormal "prop_6_20"
-  8/21 EntryNormal ""
+  1/12 EntryNormal "prop_1_12"
+  1/13 EntryNormal "prop_1_13"
+  8/14 EntryNormal ""
   Messages:
-  4->1 MsgAppResp Term:8 Log:0/21
+  4->1 MsgAppResp Term:8 Log:0/14
 > 1 receiving messages
-  4->1 MsgAppResp Term:8 Log:0/21
+  4->1 MsgAppResp Term:8 Log:0/14
 
 stabilize 1 5
 ----
 > 5 receiving messages
-  1->5 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+  1->5 MsgApp Term:8 Log:1/13 Commit:11 Entries:[8/14 EntryNormal ""]
 > 5 handling Ready
   Ready MustSync=false:
   Lead:1 State:StateFollower
   Messages:
-  5->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 18)
+  5->1 MsgAppResp Term:8 Log:1/13 Rejected (Hint: 11)
 > 1 receiving messages
-  5->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 18)
+  5->1 MsgAppResp Term:8 Log:1/13 Rejected (Hint: 11)
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->5 MsgApp Term:8 Log:6/18 Commit:21 Entries:[6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+  1->5 MsgApp Term:8 Log:1/11 Commit:14 Entries:[1/12 EntryNormal "prop_1_12", 1/13 EntryNormal "prop_1_13", 8/14 EntryNormal ""]
 > 5 receiving messages
-  1->5 MsgApp Term:8 Log:6/18 Commit:21 Entries:[6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
-  INFO found conflict at index 19 [existing term: 7, conflicting term: 6]
-  INFO replace the unstable entries from index 19
+  1->5 MsgApp Term:8 Log:1/11 Commit:14 Entries:[1/12 EntryNormal "prop_1_12", 1/13 EntryNormal "prop_1_13", 8/14 EntryNormal ""]
+  INFO found conflict at index 12 [existing term: 2, conflicting term: 1]
+  INFO replace the unstable entries from index 12
 > 5 handling Ready
   Ready MustSync=true:
-  HardState Term:8 Commit:21
+  HardState Term:8 Commit:14
   Entries:
-  6/19 EntryNormal "prop_6_19"
-  6/20 EntryNormal "prop_6_20"
-  8/21 EntryNormal ""
+  1/12 EntryNormal "prop_1_12"
+  1/13 EntryNormal "prop_1_13"
+  8/14 EntryNormal ""
   CommittedEntries:
-  6/19 EntryNormal "prop_6_19"
-  6/20 EntryNormal "prop_6_20"
-  8/21 EntryNormal ""
+  1/12 EntryNormal "prop_1_12"
+  1/13 EntryNormal "prop_1_13"
+  8/14 EntryNormal ""
   Messages:
-  5->1 MsgAppResp Term:8 Log:0/21
+  5->1 MsgAppResp Term:8 Log:0/14
 > 1 receiving messages
-  5->1 MsgAppResp Term:8 Log:0/21
+  5->1 MsgAppResp Term:8 Log:0/14
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->5 MsgApp Term:8 Log:8/21 Commit:21
+  1->5 MsgApp Term:8 Log:8/14 Commit:14
 > 5 receiving messages
-  1->5 MsgApp Term:8 Log:8/21 Commit:21
+  1->5 MsgApp Term:8 Log:8/14 Commit:14
 > 5 handling Ready
   Ready MustSync=false:
   Messages:
-  5->1 MsgAppResp Term:8 Log:0/21
+  5->1 MsgAppResp Term:8 Log:0/14
 > 1 receiving messages
-  5->1 MsgAppResp Term:8 Log:0/21
+  5->1 MsgAppResp Term:8 Log:0/14
 
 stabilize 1 6
 ----
 > 6 receiving messages
-  1->6 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+  1->6 MsgApp Term:8 Log:1/13 Commit:11 Entries:[8/14 EntryNormal ""]
 > 6 handling Ready
   Ready MustSync=false:
   Lead:1 State:StateFollower
   Messages:
-  6->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 17)
+  6->1 MsgAppResp Term:8 Log:1/13 Rejected (Hint: 11)
 > 1 receiving messages
-  6->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 17)
+  6->1 MsgAppResp Term:8 Log:1/13 Rejected (Hint: 11)
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->6 MsgApp Term:8 Log:4/15 Commit:21 Entries:[5/16 EntryNormal "", 5/17 EntryNormal "prop_5_17", 6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+  1->6 MsgApp Term:8 Log:1/11 Commit:14 Entries:[1/12 EntryNormal "prop_1_12", 1/13 EntryNormal "prop_1_13", 8/14 EntryNormal ""]
 > 6 receiving messages
-  1->6 MsgApp Term:8 Log:4/15 Commit:21 Entries:[5/16 EntryNormal "", 5/17 EntryNormal "prop_5_17", 6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
-  INFO found conflict at index 16 [existing term: 4, conflicting term: 5]
-  INFO replace the unstable entries from index 16
+  1->6 MsgApp Term:8 Log:1/11 Commit:14 Entries:[1/12 EntryNormal "prop_1_12", 1/13 EntryNormal "prop_1_13", 8/14 EntryNormal ""]
 > 6 handling Ready
   Ready MustSync=true:
-  HardState Term:8 Vote:1 Commit:21
+  HardState Term:8 Vote:1 Commit:14
   Entries:
-  5/16 EntryNormal ""
-  5/17 EntryNormal "prop_5_17"
-  6/18 EntryNormal ""
-  6/19 EntryNormal "prop_6_19"
-  6/20 EntryNormal "prop_6_20"
-  8/21 EntryNormal ""
+  1/12 EntryNormal "prop_1_12"
+  1/13 EntryNormal "prop_1_13"
+  8/14 EntryNormal ""
   CommittedEntries:
-  5/16 EntryNormal ""
-  5/17 EntryNormal "prop_5_17"
-  6/18 EntryNormal ""
-  6/19 EntryNormal "prop_6_19"
-  6/20 EntryNormal "prop_6_20"
-  8/21 EntryNormal ""
+  1/12 EntryNormal "prop_1_12"
+  1/13 EntryNormal "prop_1_13"
+  8/14 EntryNormal ""
   Messages:
-  6->1 MsgAppResp Term:8 Log:0/21
+  6->1 MsgAppResp Term:8 Log:0/14
 > 1 receiving messages
-  6->1 MsgAppResp Term:8 Log:0/21
+  6->1 MsgAppResp Term:8 Log:0/14
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->6 MsgApp Term:8 Log:8/21 Commit:21
+  1->6 MsgApp Term:8 Log:8/14 Commit:14
 > 6 receiving messages
-  1->6 MsgApp Term:8 Log:8/21 Commit:21
+  1->6 MsgApp Term:8 Log:8/14 Commit:14
 > 6 handling Ready
   Ready MustSync=false:
   Messages:
-  6->1 MsgAppResp Term:8 Log:0/21
+  6->1 MsgAppResp Term:8 Log:0/14
 > 1 receiving messages
-  6->1 MsgAppResp Term:8 Log:0/21
+  6->1 MsgAppResp Term:8 Log:0/14
 
 stabilize 1 7
 ----
 > 7 receiving messages
-  1->7 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+  1->7 MsgApp Term:8 Log:1/13 Commit:11 Entries:[8/14 EntryNormal ""]
 > 7 handling Ready
   Ready MustSync=false:
   Lead:1 State:StateFollower
   Messages:
-  7->1 MsgAppResp Term:8 Log:3/20 Rejected (Hint: 20)
+  7->1 MsgAppResp Term:8 Log:1/13 Rejected (Hint: 11)
 > 1 receiving messages
-  7->1 MsgAppResp Term:8 Log:3/20 Rejected (Hint: 20)
+  7->1 MsgAppResp Term:8 Log:1/13 Rejected (Hint: 11)
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->7 MsgApp Term:8 Log:1/13 Commit:21 Entries:[4/14 EntryNormal "", 4/15 EntryNormal "prop_4_15", 5/16 EntryNormal "", 5/17 EntryNormal "prop_5_17", 6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+  1->7 MsgApp Term:8 Log:1/11 Commit:14 Entries:[1/12 EntryNormal "prop_1_12", 1/13 EntryNormal "prop_1_13", 8/14 EntryNormal ""]
 > 7 receiving messages
-  1->7 MsgApp Term:8 Log:1/13 Commit:21 Entries:[4/14 EntryNormal "", 4/15 EntryNormal "prop_4_15", 5/16 EntryNormal "", 5/17 EntryNormal "prop_5_17", 6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
-  INFO found conflict at index 14 [existing term: 2, conflicting term: 4]
-  INFO replace the unstable entries from index 14
+  1->7 MsgApp Term:8 Log:1/11 Commit:14 Entries:[1/12 EntryNormal "prop_1_12", 1/13 EntryNormal "prop_1_13", 8/14 EntryNormal ""]
+  INFO found conflict at index 12 [existing term: 2, conflicting term: 1]
+  INFO replace the unstable entries from index 12
 > 7 handling Ready
   Ready MustSync=true:
-  HardState Term:8 Vote:1 Commit:21
+  HardState Term:8 Commit:14
   Entries:
-  4/14 EntryNormal ""
-  4/15 EntryNormal "prop_4_15"
-  5/16 EntryNormal ""
-  5/17 EntryNormal "prop_5_17"
-  6/18 EntryNormal ""
-  6/19 EntryNormal "prop_6_19"
-  6/20 EntryNormal "prop_6_20"
-  8/21 EntryNormal ""
+  1/12 EntryNormal "prop_1_12"
+  1/13 EntryNormal "prop_1_13"
+  8/14 EntryNormal ""
   CommittedEntries:
-  4/14 EntryNormal ""
-  4/15 EntryNormal "prop_4_15"
-  5/16 EntryNormal ""
-  5/17 EntryNormal "prop_5_17"
-  6/18 EntryNormal ""
-  6/19 EntryNormal "prop_6_19"
-  6/20 EntryNormal "prop_6_20"
-  8/21 EntryNormal ""
+  1/12 EntryNormal "prop_1_12"
+  1/13 EntryNormal "prop_1_13"
+  8/14 EntryNormal ""
   Messages:
-  7->1 MsgAppResp Term:8 Log:0/21
+  7->1 MsgAppResp Term:8 Log:0/14
 > 1 receiving messages
-  7->1 MsgAppResp Term:8 Log:0/21
+  7->1 MsgAppResp Term:8 Log:0/14
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->7 MsgApp Term:8 Log:8/21 Commit:21
+  1->7 MsgApp Term:8 Log:8/14 Commit:14
 > 7 receiving messages
-  1->7 MsgApp Term:8 Log:8/21 Commit:21
+  1->7 MsgApp Term:8 Log:8/14 Commit:14
 > 7 handling Ready
   Ready MustSync=false:
   Messages:
-  7->1 MsgAppResp Term:8 Log:0/21
+  7->1 MsgAppResp Term:8 Log:0/14
 > 1 receiving messages
-  7->1 MsgAppResp Term:8 Log:0/21
+  7->1 MsgAppResp Term:8 Log:0/14


### PR DESCRIPTION
For a cluster with only one member, the raft always send identical
unstable entries and committed entries to etcdserver, and etcd
responds to the client once it finishes (actually partially) the
applying workflow.

When the client receives the response, it doesn't mean etcd has already
successfully saved the data, including BoltDB and WAL, because:
   1. etcd commits the boltDB transaction periodically instead of on each request;
   2. etcd saves WAL entries in parallel with applying the committed entries.
Accordingly, it may run into a situation of data loss when the etcd crashes
immediately after responding to the client and before the boltDB and WAL
successfully save the data to disk.
Note that this issue can only happen for clusters with only one member.

For clusters with multiple members, it isn't an issue, because etcd will
not commit & apply the data before it being replicated to majority members.
When the client receives the response, it means the data must have been applied.
It further means the data must have been committed.
Note: for clusters with multiple members, the raft will never send identical
unstable entries and committed entries to etcdserver.

Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
