### PR TITLE
release: support kick off release in current branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,4 +21,4 @@ jobs:
         Name-Email: github-action@etcd.io
         Expire-Date: 0
         EOF
-        DRY_RUN=true BRANCH=main ./scripts/release.sh --no-upload --no-docker-push 3.6.99
+        DRY_RUN=true ./scripts/release.sh --no-upload --no-docker-push --current-branch 3.6.99

--- a/scripts/build-binary.sh
+++ b/scripts/build-binary.sh
@@ -7,7 +7,6 @@ source ./scripts/test_lib.sh
 VER=$1
 REPOSITORY="${REPOSITORY:-git@github.com:etcd-io/etcd.git}"
 
-
 if [ -z "$1" ]; then
   echo "Usage: ${0} VERSION" >> /dev/stderr
   exit 255
@@ -25,9 +24,9 @@ function setup_env {
 
   pushd "${proj}" >/dev/null
     run git fetch --all
-    git_assert_branch_in_sync || exit 2
+    #git_assert_branch_in_sync || exit 2
     run git checkout "${ver}"
-    git_assert_branch_in_sync || exit 2
+    #git_assert_branch_in_sync || exit 2
   popd >/dev/null
 }
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -41,6 +41,7 @@ help() {
   echo "  flags:"
   echo "    --no-upload: skip gs://etcd binary artifact uploads."
   echo "    --no-docker-push: skip docker image pushes."
+  echo "    --current-branch: build binaries in current branch."
   echo ""
   echo "One can perform a (dry-run) test release from any (uncommitted) branch using:"
   echo "  DRY_RUN=true REPOSITORY=\`pwd\` BRANCH='local-branch-name' ./scripts/release 3.5.0-foobar.2"
@@ -54,8 +55,15 @@ main() {
   fi
   RELEASE_VERSION="v${VERSION}"
   MINOR_VERSION=$(echo "${VERSION}" | cut -d. -f 1-2)
-  BRANCH=${BRANCH:-"release-${MINOR_VERSION}"}
-  REPOSITORY=${REPOSITORY:-"https://github.com/etcd-io/etcd.git"}
+
+  if [ "${CURRENT_BRANCH}" == 1 ]; then
+      # Trigger release in current branch, used in github workflow
+      REPOSITORY=$(pwd)
+      BRANCH=$(git rev-parse --abbrev-ref HEAD)
+  else
+      REPOSITORY=${REPOSITORY:-"https://github.com/etcd-io/etcd.git"}
+      BRANCH=${BRANCH:-"release-${MINOR_VERSION}"}
+  fi
 
   log_warning "DRY_RUN=${DRY_RUN}"
   log_callout "RELEASE_VERSION=${RELEASE_VERSION}"
@@ -78,18 +86,19 @@ main() {
   # Set up release directory.
   local reldir="/tmp/etcd-release-${VERSION}"
   log_callout "Preparing temporary directory: ${reldir}"
-  if [ ! -d "${reldir}/etcd" ]; then
+  if [ ! -d "${reldir}/etcd" ] && [ "${CURRENT_BRANCH}" == 0 ]; then
     mkdir -p "${reldir}"
     cd "${reldir}"
     run git clone "${REPOSITORY}" --branch "${BRANCH}"
+    run cd "${reldir}/etcd" || exit 2
+    run git checkout "${BRANCH}" || exit 2
+    run git pull origin
+
+    git_assert_branch_in_sync || exit 2
   fi
-  run cd "${reldir}/etcd" || exit 2
+
   # mark local directory as root for test_lib scripts executions
   set_root_dir
-
-  run git checkout "${BRANCH}" || exit 2
-  run git pull origin
-  git_assert_branch_in_sync || exit 2
 
   # If a release version tag already exists, use it.
   local remote_tag_exists
@@ -101,6 +110,7 @@ main() {
   fi
 
   # Check go version.
+  log_callout "Check go version"
   local go_version current_go_version
   go_version="go$(grep go-version .github/workflows/build.yaml | awk '{print $2}' | tr -d '"')"
   current_go_version=$(go version | awk '{ print $3 }')
@@ -110,6 +120,7 @@ main() {
   fi
 
   # If the release tag does not already exist remotely, create it.
+  log_callout "Create tag if not present"
   if [ "${remote_tag_exists}" -eq 0 ]; then
     # Bump version/version.go to release version.
     local source_version
@@ -148,7 +159,7 @@ main() {
     fi
 
     # Push the version change if it's not already been pushed.
-    if [ "$DRY_RUN" != "true" ] && [ "$(git rev-list --count "origin/${BRANCH}..${BRANCH}")" -gt 0 ]; then
+    if [ "${DRY_RUN}" != "true" ] && [ "$(git rev-list --count "origin/${BRANCH}..${BRANCH}")" -gt 0 ]; then
       read -p "Push version bump up to ${VERSION} to '$(git remote get-url origin)' [y/N]? " -r confirm
       [[ "${confirm,,}" == "y" ]] || exit 1
       maybe_run git push
@@ -162,15 +173,23 @@ main() {
       REMOTE_REPO="origin" push_mod_tags_cmd
     fi
 
-    # Verify the version tag is on the right branch
-    # shellcheck disable=SC2155
-    local branch=$(git for-each-ref --contains "${RELEASE_VERSION}" --format="%(refname)" 'refs/heads' | cut -d '/' -f 3)
-    if [ "${branch}" != "${BRANCH}" ]; then
-      log_error "Error: Git tag ${RELEASE_VERSION} should be on branch '${BRANCH}' but is on '${branch}'"
-      exit 1
+    if [ "${CURRENT_BRANCH}" == 0 ]; then
+      # Tried with `local branch=$(git branch -a --contains tags/"${RELEASE_VERSION}")`
+      # so as to work with both current branch and main/release-3.X.
+      # But got error below on current branch mode,
+      # Error: Git tag v3.6.99 should be on branch '* (HEAD detached at pull/14860/merge)' but is on '* (HEAD detached from pull/14860/merge)'
+      #
+      # Verify the version tag is on the right branch
+      # shellcheck disable=SC2155
+      local branch=$(git for-each-ref --contains "${RELEASE_VERSION}" --format="%(refname)" 'refs/heads' | cut -d '/' -f 3)
+      if [ "${branch}" != "${BRANCH}" ]; then
+        log_error "Error: Git tag ${RELEASE_VERSION} should be on branch '${BRANCH}' but is on '${branch}'"
+        exit 1
+      fi
     fi
   fi
 
+  log_callout "Verify the latest commit has the version tag"
   # Verify the latest commit has the version tag
   # shellcheck disable=SC2155
   local tag="$(git describe --exact-match HEAD)"
@@ -179,6 +198,7 @@ main() {
     exit 1
   fi
 
+  log_callout "Verify the work space is clean"
   # Verify the clean working tree
   # shellcheck disable=SC2155
   local diff="$(git diff HEAD --stat)"
@@ -215,7 +235,7 @@ main() {
   fi
 
   # Upload artifacts.
-  if [ "${NO_UPLOAD}" == 1 ]; then
+  if [ "${DRY_RUN}" == "true" ] || [ "${NO_UPLOAD}" == 1 ]; then
     log_callout "Skipping artifact upload to gs://etcd. --no-upload flat is set."
   else
     read -p "Upload etcd ${RELEASE_VERSION} release artifacts to gs://etcd [y/N]? " -r confirm
@@ -227,7 +247,7 @@ main() {
   fi
 
   # Push images.
-  if [ "${NO_DOCKER_PUSH}" == 1 ]; then
+  if [ "${DRY_RUN}" == "true" ] || [ "${NO_DOCKER_PUSH}" == 1 ]; then
     log_callout "Skipping docker push. --no-docker-push flat is set."
   else
     read -p "Publish etcd ${RELEASE_VERSION} docker images to quay.io [y/N]? " -r confirm
@@ -308,6 +328,7 @@ main() {
 POSITIONAL=()
 NO_UPLOAD=0
 NO_DOCKER_PUSH=0
+CURRENT_BRANCH=0
 
 while test $# -gt 0; do
         case "$1" in
@@ -315,6 +336,10 @@ while test $# -gt 0; do
             shift
             help
             exit 0
+            ;;
+          --current-branch)
+            CURRENT_BRANCH=1
+            shift
             ;;
           --no-upload)
             NO_UPLOAD=1
@@ -335,6 +360,13 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 if [[ ! $# -eq 1 ]]; then
   help
   exit 1
+fi
+
+# Note that we shouldn't upload artifacts in --current-branch mode, so it
+# must be called with DRY_RUN=true
+if [ "${DRY_RUN}" != "true" ] && [ "${CURRENT_BRANCH}" == 1 ]; then
+   log_error "--current-branch should only be called with DRY_RUN=true"
+   exit 1
 fi
 
 main "$1"

--- a/scripts/test_lib.sh
+++ b/scripts/test_lib.sh
@@ -410,9 +410,10 @@ function assert_no_git_modifications {
 #  - no differencing commits in relation to the origin/$branch
 function git_assert_branch_in_sync {
   local branch
-  branch=$(run git rev-parse --abbrev-ref HEAD)
   # TODO: When git 2.22 popular, change to:
   # branch=$(git branch --show-current)
+  branch=$(run git rev-parse --abbrev-ref HEAD)
+  log_callout "Verify the current branch '${branch}' is in sync with the origin branch"
   if [[ $(run git status --porcelain --untracked-files=no) ]]; then
     log_error "The workspace in '$(pwd)' for branch: ${branch} has uncommitted changes"
     log_error "Consider cleaning up / renaming this directory or (cd $(pwd) && git reset --hard)"


### PR DESCRIPTION
Currently when triggering release, it always pull remote repo and checkout main branch. Any changes which are merged into the target release branch (e.g. release-3.5) will be ignored. It isn't convenient for test, including in github workflow and local environment. So we need to support triggering release in current branch.

Note: --current-branch should only be called with DRY_RUN=true

Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
